### PR TITLE
add GHCR, mutiarch and cache

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,10 +2,17 @@ name: docker_build
 
 on:
   push:
-    branches:
-      - 'master'
     paths:
       - 'images/**'
+      - '.github/workflows/docker-build.yml'
+    branches:
+    - main
+  pull_request: #They will only build the containers, not push them
+    types:
+    - opened
+    - reopened
+  schedule:
+  - cron: "0 0 * * *" #nightly
   workflow_dispatch:
 
 jobs:
@@ -13,40 +20,119 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image_name: [xorg, pulseaudio, udevd, sunshine, retroarch, steam]
+        image:
+        - { name: xorg,       platforms: "linux/amd64,linux/arm64" }
+        - { name: pulseaudio, platforms: "linux/amd64,linux/arm64" }
+        - { name: udevd,      platforms: "linux/amd64,linux/arm64" }
+        - { name: sunshine,   platforms: "linux/amd64" }
+        - { name: retroarch,  platforms: "linux/amd64,linux/arm64" }
+        - { name: steam,      platforms: "linux/amd64"             }
+      fail-fast: false
     steps:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      # Set derived configuration variables:
+      # - images: images to build (docker and/or github)
+      # - push: if images need to be uploaded to repository (when secrets available)
+      # - has_docker_token
+      # - has_github_token
+      # - cache_from: image tag to use for imported cache
+      # - cache_to: image tag to use for exported cache
+      # - github_server_url: reference to source code repository
+
+      - name: Prepare
+        id: prep
+        run: |
+          IMAGES="${{ matrix.image.name }}"
+          PUSH=false
+
+          if [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            if [[ $github.repository_owner == game-on-whales ]]; then
+              # For oficial repository, github and org names do not match
+              IMAGES="gameonwhales/${{ matrix.image.name }}"
+            else
+              # By default, assume docker and github org names match
+              IMAGES="${{ github.repository_owner }}/${{ matrix.image.name }}"
+            fi
+            PUSH=true
+            echo ::set-output name=has_docker_token::true
+          fi
+
+          if [ -n "${{ secrets.GHCR_TOKEN }}" ]; then
+            REGISTRY_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}"
+            IMAGES="$IMAGES,ghcr.io/${REGISTRY_IMAGE}"
+            PUSH=true
+            echo ::set-output name=has_github_token::true
+            echo ::set-output name=cache_from::"type=registry,ref=${REGISTRY_IMAGE}:buildcache"
+            echo ::set-output name=cache_to::"type=registry,ref=${REGISTRY_IMAGE}:buildcache,mode=max"
+          else
+            echo ::set-output name=cache_from::"type=registry,ref=${REGISTRY_IMAGE}:buildcache"
+            echo ::set-output name=cache_to::""
+          fi
+
+          echo ::set-output name=images::"${IMAGES}"
+          echo ::set-output name=push::${PUSH}
+          echo ::set-output name=github_server_url::"${GITHUB_SERVER_URL}"
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
           # list of Docker images to use as base name for tags
-          images: gameonwhales/${{ matrix.image_name }}
+          images: ${{ steps.prep.outputs.images }}
           # generate Docker tags based on the following events/attributes
-          tags: type=sha
-          flavor: latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=edge,branch=master
+            type=sha
+          flavor: latest=auto #latest will point to last semver version (stable)
+
+      # Prepare for multi-arch
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
 
       - name: Login to DockerHub
+        if: steps.prep.outputs.has_docker_token != '' # secrets not available in PRs
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Login to GitHub Container Registry
+        if: steps.prep.outputs.has_github_token != '' # secrets not available in PRs
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: ./images/
-          file: ./images/${{ matrix.image_name }}/Dockerfile
-          push: true
+          file: ./images/${{ matrix.image.name }}/Dockerfile
+          platforms: ${{ matrix.image.platforms }}
+          push: ${{ steps.prep.outputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            IMAGE_SOURCE=${{ steps.prep.outputs.github_server_url }}/${{ github.repository }}
+          cache-from: ${{ steps.prep.outputs.cache_from }}
+          cache-to: ${{ steps.prep.outputs.cache_to }}
 
       - name: Image digest
-        run: echo "${{ matrix.image_name }} > ${{ steps.docker_build.outputs.digest }}"
+        run: echo "${{ matrix.image.name }} > ${{ steps.docker_build.outputs.digest }}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,9 +2,8 @@ name: docker_build
 
 on:
   push:
-    paths:
-      - 'images/**'
-      - '.github/workflows/docker-build.yml'
+    tags:
+    - "v*.*.*"
     branches:
     - main
   pull_request: #They will only build the containers, not push them

--- a/images/pulseaudio/Dockerfile
+++ b/images/pulseaudio/Dockerfile
@@ -26,3 +26,6 @@ COPY --chmod=777 common/* /bin/
 EXPOSE 4713
 
 CMD /bin/bash /startup.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -36,3 +36,6 @@ COPY retroarch/scripts/startup.sh /startup.sh
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
 
 CMD /bin/bash /startup.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -48,3 +48,6 @@ COPY steam/scripts/startup.sh /startup.sh
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
 
 CMD /bin/bash /startup.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -87,3 +87,6 @@ EXPOSE 48010/udp
 EXPOSE 47998-48000/udp
 
 CMD /bin/bash /startup.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/udevd/Dockerfile
+++ b/images/udevd/Dockerfile
@@ -12,3 +12,6 @@ COPY --chmod=777 common/* /bin/
 COPY udevd/scripts/startup.sh /startup.sh
 
 CMD /bin/bash /startup.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/xorg/Dockerfile
+++ b/images/xorg/Dockerfile
@@ -32,3 +32,6 @@ COPY --chmod=777 common/* /bin/
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
 
 CMD /bin/bash /startup.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE


### PR DESCRIPTION
This PR adds the following features to the build actions:
- upload to GitHub Container Registry in parallel to Docker Hub. This requires:
  - create a token for GHCR - see [instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
  - github repository secrets:
    - GHCR_USERNAME
    - GHCR_TOKEN
- multiarch support (steam and shunsine do not build on arm64 yet so disabled)
- cache: cache latest build
- nightly builds
- new tags:
  - stable versions using semver - tag with v1.0.0 (or better, [draft a release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/managing-releases-in-a-repository))
  - edge: latest commit to master branch (build on each push or by nightly schedule)
  - latest points to latest stable version

## container in GHCR 
![image](https://user-images.githubusercontent.com/4406403/131204261-38fc21f6-efb0-4084-b5bf-c3db92b33d1a.png)
