### PR TITLE
increase SHM for retroarch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,12 @@ services:
       - ${PULSE_SOCKET_HOST}:${PULSE_SOCKET_GUEST}
       # Home directory: retroarch games, downloads, cores etc
       - ${local_state}/:/home/retro/
+      # some emulators need more than 64 MB of shared memory - see https://github.com/libretro/dolphin/issues/222
+      # TODO: why shm_size doesn't work ??????
+      - type: tmpfs
+        target: /dev/shm
+        tmpfs:
+            size: 500M
     ipc: ${SHARED_IPC}  # Needed for MIT-SHM, removing this should cause a performance hit see https://github.com/jessfraz/dockerfiles/issues/359
     environment:
       DISPLAY: ${XORG_DISPLAY}


### PR DESCRIPTION
Without this some emulators such as Dolphin crash.

See https://github.com/libretro/dolphin/issues/222

Related Helm chart fix: https://github.com/k8s-at-home/charts/pull/1142