### PR TITLE
Explicitly specify that PULSE_SERVER is an unix socket

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ XORG_DISPLAY=:99
 # Using network in order to connect to pulse
 # if you do have a pulse server already point this to the pulse socket like unix:/tmp/pulse-sock
 # and mount the host socket to the instance
-PULSE_SERVER=/tmp/pulse/pulse-socket
+PULSE_SERVER=unix:/tmp/pulse/pulse-socket
 PULSE_SOCKET_HOST=pulse
 PULSE_SOCKET_GUEST=/tmp/pulse/
 


### PR DESCRIPTION
It seems that the runtime for Proton 5.13+ is unable to correctly parse PULSE_SERVER and mount it unless it is mentioned that it is a unix socket. On failing to use pulseaudio, the runtime tries to use ALSA which fails as expected. As a consequence, some games fail with a segfault.