### PR TITLE
Remove redundant `udev` volume

### DIFF
--- a/compose/headless.yml
+++ b/compose/headless.yml
@@ -74,4 +74,3 @@ services:
 volumes:
   xorg: # This will hold the xorg socket file and it'll be shared between containers
   pulse: # This will hold the xorg socket
-  udev: # This will hold shared udev files


### PR DESCRIPTION
When I moved the `udev` volume to `docker-compose.yml`, I forgot to check in the change that _removed_ it from this file.  Oops!