### PR TITLE
Unprivileged udev

### DIFF
--- a/compose/headless.yml
+++ b/compose/headless.yml
@@ -16,6 +16,10 @@ services:
 #       BASE_APP_IMAGE: ${BUILD_BASE_APP_IMAGE}
     runtime: ${DOCKER_RUNTIME}
     network_mode: ${UDEVD_NETWORK}
+    # The xorg container needs to be privileged to have access to all of the devices it requires.
+    # NOTE: actually, all it _really_ needs is CAP_SYS_TTY_CONFIG plus a
+    # devices: entry for each required device. Unfortunately, the list of
+    # required devices will vary based on host and is hard to predict.
     privileged: true
     volumes:
       # Shared with Sunshine in order to get mouse and joypad working
@@ -60,12 +64,9 @@ services:
 #     args:
 #       BASE_IMAGE: ${BUILD_BASE_IMAGE}
 #       BASE_APP_IMAGE: ${BUILD_BASE_APP_IMAGE}
-#    # Setting network to host
-#    # There must be a way to avoid this but I can't figure it out
-#    # We need to be on the host network in order to get the PF_NETLINK socket
-#    # You can listen to events even without that socket but Xorg and RetroArch will not pickup the devices
-    network_mode: host
-    privileged: true
+
+    cap_add:
+      - NET_ADMIN
     volumes:
       - udev:/run/udev/
 

--- a/images/udevd/Dockerfile
+++ b/images/udevd/Dockerfile
@@ -9,5 +9,7 @@ RUN apt-get update -y && \
 
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup.sh
 
+ENV UDEVD_QUIET=false
+
 ARG IMAGE_SOURCE
 LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/udevd/scripts/startup.sh
+++ b/images/udevd/scripts/startup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+
 set -e
+
+source /opt/gow/bash-lib/utils.sh
 
 function start_udev() {
 	# mount_dev
@@ -8,8 +11,14 @@ function start_udev() {
     else
         nsenter /lib/systemd/systemd-udevd --daemon &> /dev/null
     fi
-    udevadm trigger &> /dev/null
+    udevadm trigger &> /dev/null || true
 }
 
 start_udev
+
+if [ "${UDEVD_QUIET:-false}" = "true" ]; then
+    # redirect stdout to /dev/null before running udevadm monitor
+    exec >/dev/null
+fi
+
 exec udevadm monitor

--- a/images/udevd/scripts/startup.sh
+++ b/images/udevd/scripts/startup.sh
@@ -4,9 +4,9 @@ set -e
 function start_udev() {
 	# mount_dev
     if command -v udevd &>/dev/null; then
-        unshare --net udevd --daemon &> /dev/null
+        nsenter udevd --daemon &> /dev/null
     else
-        unshare --net /lib/systemd/systemd-udevd --daemon &> /dev/null
+        nsenter /lib/systemd/systemd-udevd --daemon &> /dev/null
     fi
     udevadm trigger &> /dev/null
 }


### PR DESCRIPTION
After much research and experimentation, I've learned that `udev` can run without `network_mode: host` and `privileged: true` by using `nsenter`.

`nsenter` is a bit like `chroot`, but for namespaces; launching the `udev` daemon through it will allow `udev` to see the necessary netlink messages from the host.

I've tested with mouse, keyboard, and controller in both Steam and Retroarch in headless mode, but I don't currently have the equipment to test host-desktop mode (I really gotta fix that :grin:). Since host-desktop mode doesn't even run `udev` I _think_ it shouldn't be affected by this change, but 🤷 .

Edit: meant to add some links to more info about `nsenter`:
 - https://man7.org/linux/man-pages/man1/nsenter.1.html
 - https://linuxhint.com/nsenter-linux-command/