### PR TITLE
Disabling unnecesary stuff from RA Main Menu 

### DIFF
--- a/images/retroarch/configs/retroarch.cfg
+++ b/images/retroarch/configs/retroarch.cfg
@@ -713,6 +713,20 @@ video_fullscreen = true
 # Only init the WIMP UI for this session if this is enabled
 # desktop_menu_enable = true
 
+# Disabling some unnecesary stuff in RA Main Menu
+menu_show_quit_retroarch = "false"
+menu_show_load_disc = "false"
+menu_show_dump_disc = "false"
+menu_show_help = "false"
+desktop_menu_enable = "false"
+content_show_images = "false"
+content_show_music = "false"
+content_show_video = "false"
+# We can disable settings submenu alltogether
+#content_show_settings = "false"
+
+
+
 #### Camera
 
 # Override the default camera device the camera driver uses. This is driver dependant.
@@ -969,4 +983,3 @@ savestate_directory = /home/retro/retroarch/savestates/
 
 # Enable device vibration for supported cores
 # enable_device_vibration = false
-

--- a/images/retroarch/configs/retroarch.cfg
+++ b/images/retroarch/configs/retroarch.cfg
@@ -725,8 +725,6 @@ content_show_video = "false"
 # We can disable settings submenu alltogether
 #content_show_settings = "false"
 
-
-
 #### Camera
 
 # Override the default camera device the camera driver uses. This is driver dependant.


### PR DESCRIPTION
Description in commit, in summary:
Disabled Quit option, so user wouldnt end up in desktop mode (maybe Quit option needs to be linked to disabling sunshine session and on reconnect just reopen retroarch) for time being i think its best to disable it
Disable Pictures/videos/Music submenus
Disable Desktop UI