### PR TITLE
Add an action to lint shell scripts and Dockerfiles

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,11 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          dotenv_linter_flags: --skip UnorderedKey
+          dotenv_linter_flags: --skip UnorderedKey user.env env/*.env config/*.env
 
       - name: YAML files
         uses: reviewdog/action-yamllint@v1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
+          yamllint_flags: 'docker-compose.yml compose/*.yml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,15 @@ jobs:
           hadolint_ignore: DL3008
           filter_mode: nofilter
 
+      - name: Environment files
+        uses: dotenv-linter/action-dotenv-linter@v2
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          dotenv_linter_flags: --skip UnorderedKey
+
+      - name: YAML files
+        uses: reviewdog/action-yamllint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
           reporter: github-pr-review
           check_all_files_with_shebangs: "true"
           filter_mode: nofilter
+          shellcheck_flags: -e SC1091
 
       - name: Dockerfiles
         uses: reviewdog/action-hadolint@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Run linters
+
+on: [ pull_request ]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Shell scripts
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          reporter: github-pr-review
+          check_all_files_with_shebangs: "true"
+          filter_mode: nofilter
+
+      - name: Dockerfiles
+        uses: reviewdog/action-hadolint@v1
+        with:
+          reporter: github-pr-review
+          # at least for now, ignore suggestions to pin specific versions of
+          # apt packages.
+          hadolint_ignore: DL3008
+          filter_mode: nofilter
+

--- a/images/base-app/Dockerfile
+++ b/images/base-app/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/base/build/setup-retro-user
+++ b/images/base/build/setup-retro-user
@@ -5,21 +5,25 @@ echo "Setting up $UNAME ($PUID:$PGID)"
 
 # Create the user and a home dir for them \
 groupadd -f -g "${PGID}" "${UNAME}"
-useradd -mk $(mktemp -d) -u "${PUID}" -g "${PGID}" "${UNAME}"
+useradd -mk "$(mktemp -d)" -u "${PUID}" -g "${PGID}" "${UNAME}"
 
 # Set up sudoers
 mkdir -p /etc/sudoers.d
 
-# $UNAME should be able to add groups without a password
-echo "${UNAME} ALL=(root) NOPASSWD: $(which groupadd)" >> /etc/sudoers.d/${UNAME}
+{
+    # $UNAME should be able to add groups without a password
+    echo "${UNAME} ALL=(root) NOPASSWD: $(which groupadd)"
 
-# $UNAME should be able to chmod without a password
-echo "${UNAME} ALL=(root) NOPASSWD: $(which chmod)" >> /etc/sudoers.d/${UNAME}
+    # $UNAME should be able to chmod without a password
+    echo "${UNAME} ALL=(root) NOPASSWD: $(which chmod)"
 
-# $UNAME should be able to add itself to groups without a password
-echo "${UNAME} ALL=(root) NOPASSWD: $(which usermod) -G * ${UNAME}" >> /etc/sudoers.d/${UNAME}
+    # $UNAME should be able to add itself to groups without a password
+    echo "${UNAME} ALL=(root) NOPASSWD: $(which usermod) -G * ${UNAME}"
 
-# $UNAME should be able to run any commands as itself without a password
-# this makes it easy to reload group memberships
-echo "${UNAME} ALL=($UNAME) NOPASSWD: ALL" >> /etc/sudoers.d/${UNAME}
-chmod 0444 /etc/sudoers.d/${UNAME}
+    # $UNAME should be able to run any commands as itself without a password
+    # this makes it easy to reload group memberships
+    echo "${UNAME} ALL=($UNAME) NOPASSWD: ALL"
+} >> "/etc/sudoers.d/${UNAME}"
+
+
+chmod 0444 "/etc/sudoers.d/${UNAME}"

--- a/images/base/scripts/bootstrap.sh
+++ b/images/base/scripts/bootstrap.sh
@@ -6,10 +6,13 @@ set -e
 source /opt/gow/bash-lib/utils.sh
 
 # make sure we're in the right groups to use all the required devices
+# we're actually relying on word splitting for this call, so disable the
+# warning from shellcheck
+# shellcheck disable=SC2086
 /opt/gow/ensure-groups ${GOW_REQUIRED_DEVICES:-/dev/uinput /dev/input/event*}
 
 gow_log "Launching the container's startup script"
 
 # launch the container's startup script. use sudo to force group memberships to
 # be reloaded, since they may have been changed by ensure-groups
-exec sudo -u $(whoami) -E /opt/gow/startup.sh
+exec sudo -u "$(whoami)" -E /opt/gow/startup.sh

--- a/images/base/scripts/lib/utils.sh
+++ b/images/base/scripts/lib/utils.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 function gow_log {
     echo "$(date +"[%Y-%m-%d %H:%M:%S]") $*"
 }

--- a/images/pulseaudio/Dockerfile
+++ b/images/pulseaudio/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
     # \
     # Install retroarch \
     add-apt-repository ppa:libretro/stable && \
-    apt-get install -y $REQUIRED_PACKAGES && \
+    apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
     # \
     # Cleanup \
     apt-get remove -y software-properties-common gpg-agent && \

--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -26,8 +26,8 @@ ENV \
     SUNSHINE_SHA=${SUNSHINE_SHA} \
     BUILD_TYPE=${BUILD_TYPE}
 
+# hadolint ignore=DL3003
 RUN git clone --recurse-submodule https://github.com/Logical-sh/Sunshine sunshine && \
-    # hadolint ignore=DL3003
     cd sunshine && \
     # Fix the SHA commit
     git checkout -qf "$SUNSHINE_SHA" && \
@@ -38,7 +38,7 @@ RUN git clone --recurse-submodule https://github.com/Logical-sh/Sunshine sunshin
     cmake \
         -DCMAKE_C_COMPILER=gcc-10 \
         -DCMAKE_CXX_COMPILER=g++-10 \
-        -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
         -DSUNSHINE_EXECUTABLE_PATH=sunshine \
         -DSUNSHINE_ASSETS_DIR=/etc/sunshine .. && \
     make -j${nproc} && \

--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -27,9 +27,10 @@ ENV \
     BUILD_TYPE=${BUILD_TYPE}
 
 RUN git clone --recurse-submodule https://github.com/Logical-sh/Sunshine sunshine && \
+    # hadolint ignore=DL3003
     cd sunshine && \
     # Fix the SHA commit
-    git checkout -qf $SUNSHINE_SHA && \
+    git checkout -qf "$SUNSHINE_SHA" && \
     # Just printing out git info so that I can double check on CI if the right version as been picked up
     git show && \
     # Normal compile
@@ -45,6 +46,8 @@ RUN git clone --recurse-submodule https://github.com/Logical-sh/Sunshine sunshin
     cpack -G DEB
 
 ######################################
+
+# hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE} AS sunshine
 
 ARG REQUIRED_PACKAGES="\
@@ -61,7 +64,7 @@ ARG REQUIRED_PACKAGES="\
 RUN \
   --mount=type=bind,from=sunshine-builder,source=/sunshine/build/cpack_artifacts/Sunshine.deb,target=/sunshine.deb \
     apt-get update -y && \
-    apt-get install -y -f /sunshine.deb && \
+    apt-get install -y --no-install-recommends -f /sunshine.deb && \
     apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/udevd/Dockerfile
+++ b/images/udevd/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/xorg/Dockerfile
+++ b/images/xorg/Dockerfile
@@ -1,4 +1,6 @@
 ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
 ENV \

--- a/images/xorg/scripts/ensure-nvidia-xorg-driver.sh
+++ b/images/xorg/scripts/ensure-nvidia-xorg-driver.sh
@@ -10,7 +10,7 @@ fi
 
 function fail() {
     (
-        if [ ! -z "${1:-}" ]; then
+        if [ -n "${1:-}" ]; then
             echo "$1"
         fi
         echo "Xorg may fail to start; try mounting drivers from your host as a volume."
@@ -28,8 +28,7 @@ for d in $NVIDIA_DRIVER_MOUNT_LOCATION $NVIDIA_PACKAGE_LOCATION; do
 done
 
 # Otherwise, try to download the correct package.
-HOST_DRIVER_VERSION=$(cat /proc/driver/nvidia/version | sed -nE 's/.*Module[ \t]+([0-9]+(\.[0-9]+)*).*/\1/p')
-HOST_DRIVER_MAJOR_VERSION=$(echo "$HOST_DRIVER_VERSION" | sed -E 's/\..+//')
+HOST_DRIVER_VERSION=$(sed -nE 's/.*Module[ \t]+([0-9]+(\.[0-9]+)*).*/\1/p' /proc/driver/nvidia/version)
 
 if [ -z "$HOST_DRIVER_VERSION" ]; then
     echo "Could not find NVIDIA driver; skipping"
@@ -60,13 +59,16 @@ if [ ! -d $EXTRACT_LOC ]; then
         exit 1
     fi
 
-    chmod +x $DL_FILE
+    chmod +x "$DL_FILE"
     $DL_FILE -x --target $EXTRACT_LOC
-    rm $DL_FILE
+    rm "$DL_FILE"
 fi
 
 if [ ! -d $NVIDIA_DRIVER_MOUNT_LOCATION ]; then
     mkdir -p $NVIDIA_DRIVER_MOUNT_LOCATION
 fi
 
-cp $EXTRACT_LOC/nvidia_drv.so $EXTRACT_LOC/libglxserver_nvidia.so.$HOST_DRIVER_VERSION $NVIDIA_DRIVER_MOUNT_LOCATION
+cp "$EXTRACT_LOC/nvidia_drv.so" "$EXTRACT_LOC/libglxserver_nvidia.so.$HOST_DRIVER_VERSION" "$NVIDIA_DRIVER_MOUNT_LOCATION"
+
+
+


### PR DESCRIPTION
Added an action to run linters for shell scripts and Dockerfiles.  It will run on any PR.  If there's a lint issue in one of the files being modified, it will add a review pointing out the specific line and error. If it finds errors in files _not_ in the PR, those will get noted under the "Checks" tab.  None of this blocks merging the PR anyway, but it should make it much easier to spot potential problems.