### PR TITLE
add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    target-branch: "master"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    target-branch: "master"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot will help keep project dependencies up to date. In this configuration I've added two package systems to monitor.

1. `docker`: This will update tags in docker files when you tag a specific version instead of `latest`. I am unsure if the docker ecosystem will recurse into directories. In one of my own repos, I found that dependabot does not recurse into directories for `npm`, although it does for `pip`, submodules, etc.
2. `github-actions`: This will update github actions when a new version is released. If you use an exact tag like `v2.1.0`, a PR will be made whenever anything newer is releaesed. If you use a major version tag like `v2` you won't get PR updates for every `v2.x.x` update, but you will for a `v3`+ release.

- I have limited this to 10 open PRs per package ecosystem as to not completely overwhelm the repo with PRs.
- I have set the branch to `master` but if in the future you use a staging/development branch you can change dependabot to monitor a different branch.

ℹ️ Note that dependabot PRs do not have access to org/repo secrets by default, but you can add secrets for dependabot at the org or repo level if you need them.
![image](https://user-images.githubusercontent.com/42013603/210669755-532f673c-1407-42f0-81ec-64c8f13ef1e1.png)

This is an example PR created by dependabot for a docker dependency. https://github.com/LizardByte/discord-bot/pull/138

And this is one for a GitHub action. https://github.com/LizardByte/Sunshine/pull/498

Using dependabot will eliminate the need to manually create PRs like this one: https://github.com/games-on-whales/gow/pull/78