### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/images/base"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    target-branch: "master"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "docker"
+    directory: "/images/sunshine"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    target-branch: "master"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    target-branch: "master"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Thanks @ReenigneArcher for opening https://github.com/games-on-whales/gow/pull/106 it looks like I can't edit that PR so I'm opening another one.

The main difference is that it seems that dependabot is not able to traverse the dockerfiles recursively so we have to manually specify the paths.