### PR TITLE
update sunshine tag to `lizardbyte/sunshine:v0.18.1-ubuntu-22.04`

### DIFF
--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_APP_IMAGE
 
 ######################################
-FROM lizardbyte/sunshine:v0.16.0 AS sunshine-image
+FROM lizardbyte/sunshine:v0.18.1-ubuntu-22.04 AS sunshine-image
 
 # hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE} AS sunshine


### PR DESCRIPTION
As of Sunshine v0.18.0 we now have images for various Linux distros and versions.

This PR updates the sunshine tag to use the `ubuntu-22.04` image, which is the equivalent of the previous single image.

More info here: https://hub.docker.com/r/lizardbyte/sunshine