### PR TITLE
Fix nvidia driver download URL

### DIFF
--- a/images/xorg/scripts/ensure-nvidia-xorg-driver.sh
+++ b/images/xorg/scripts/ensure-nvidia-xorg-driver.sh
@@ -49,7 +49,7 @@ function download_pkg() {
     fi
 }
 
-DOWNLOAD_URL=https://us.download.nvidia.com/XFree86/Linux-x86_64/$HOST_DRIVER_VERSION/NVIDIA-Linux-x86_64-$HOST_DRIVER_VERSION.run
+DOWNLOAD_URL=https://download.nvidia.com/XFree86/Linux-x86_64/$HOST_DRIVER_VERSION/NVIDIA-Linux-x86_64-$HOST_DRIVER_VERSION.run
 DL_FILE=/tmp/nvidia-$HOST_DRIVER_VERSION.run
 EXTRACT_LOC=/tmp/nvidia-drv
 


### PR DESCRIPTION
us.download.nvidia.com doesn't work anymore, but without the us, the links work fine. 

e.g. 
404: https://us.download.nvidia.com/XFree86/Linux-x86_64/525.60.13/NVIDIA-Linux-x86_64-525.60.13.run
200: https://download.nvidia.com/XFree86/Linux-x86_64/525.60.13/NVIDIA-Linux-x86_64-525.60.13.run