### PR TITLE
Adding missing packages to RetroArch Dockerfile - partially-fixes Dolphin core and fixes PCSX2

### DIFF
--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -11,7 +11,7 @@ ARG REQUIRED_PACKAGES=" \
 "
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common gpg-agent && \
+    apt-get install -y --no-install-recommends software-properties-common gpg-agent libusb-1.0-0 && \
     # \
     # Install retroarch \
     add-apt-repository ppa:libretro/stable && \

--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -11,7 +11,7 @@ ARG REQUIRED_PACKAGES=" \
 "
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common gpg-agent libusb-1.0-0 && \
+    apt-get install -y --no-install-recommends software-properties-common gpg-agent libusb-1.0-0 libglu1-mesa libaio1 libaio-dev && \
     # \
     # Install retroarch \
     add-apt-repository ppa:libretro/stable && \


### PR DESCRIPTION
Example of the core crash:
![image](https://user-images.githubusercontent.com/41058180/217527089-b5641b7b-d7c2-4396-8868-a6e7ac82c58f.png)

After installing core progresses further but still hangs:
![image](https://user-images.githubusercontent.com/41058180/217527487-f4b6ae1a-9b2c-476a-9d42-d20458239348.png)
