### PR TITLE
enable arm64 builds for base, sunshine, retroarch

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -32,7 +32,7 @@ jobs:
         - { name: xorg,       platforms: "linux/amd64,linux/arm64" }
         - { name: pulseaudio, platforms: "linux/amd64,linux/arm64" }
         - { name: udevd,      platforms: "linux/amd64,linux/arm64" }
-        - { name: sunshine,   platforms: "linux/amd64" }
+        - { name: sunshine,   platforms: "linux/amd64,linux/arm64" }
         - { name: retroarch,  platforms: "linux/amd64,linux/arm64" }
         - { name: steam,      platforms: "linux/amd64"             }
       fail-fast: false

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM ubuntu:22.04
 
 # Configure default user and set env
@@ -9,44 +11,50 @@ ENV \
     UNAME="retro" \
     HOME="/home/retro" \
     TZ="Europe/London"
-RUN \
-    echo "**** Configure default user '${UNAME}' ****" \
-        && useradd -m -d ${HOME} -s /bin/bash ${UNAME} \
-    && \
-    echo
+
+ARG TARGETARCH TARGETVARIANT
+
+RUN <<_CONF_USER
+set -e
+echo "**** Configure default user '${UNAME}' ****"
+useradd -m -d ${HOME} -s /bin/bash ${UNAME}
+echo
+_CONF_USER
 
 # Install default required packages
 ARG DEBIAN_FRONTEND=noninteractive
-# TODO: If we need to download multi arch, then this will beed to be updated
 ARG GOSU_VERSION=1.14
-RUN \
-    echo "**** Update apt database ****" \
-        && apt-get update \
-    && \
-    echo "**** Install certificates ****" \
-        && apt-get install -y --reinstall --no-install-recommends \
-            ca-certificates \
-    && \
-    echo "**** Install base packages ****" \
-        && apt-get install -y --no-install-recommends \
-            fuse \
-            libnss3 \
-            wget \
-    && \
-    echo "**** Install gosu ****" \
-        && wget --progress=dot:giga \
-            -O /usr/bin/gosu \
-            https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64 \
-        && chmod +x /usr/bin/gosu \
-    && \
-    echo "**** Verify gosu works ****" \
-        && gosu nobody true && echo "Working!" \
-    && \
-    echo "**** Section cleanup ****" \
-        && rm -rf \
-            /var/lib/apt/lists/* \
-    && \
-    echo
+
+RUN <<_INSTALL_PACKAGES
+set -e
+echo "**** Update apt database ****"
+apt-get update
+
+echo "**** Install certificates ****"
+apt-get install -y --reinstall --no-install-recommends \
+    ca-certificates
+
+echo "**** Install base packages ****"
+apt-get install -y --no-install-recommends \
+    fuse \
+    libnss3 \
+    wget
+
+echo "**** Install gosu ****"
+wget --progress=dot:giga \
+    -O /usr/bin/gosu \
+    https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH}${TARGETVARIANT}
+chmod +x /usr/bin/gosu
+
+echo "**** Verify gosu works ****"
+gosu nobody true && echo "Working!"
+
+echo "**** Section cleanup ****"
+rm -rf \
+    /var/lib/apt/lists/*
+
+echo
+_INSTALL_PACKAGES
 
 # Import overlay
 COPY overlay /

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -43,7 +43,7 @@ apt-get install -y --no-install-recommends \
 echo "**** Install gosu ****"
 wget --progress=dot:giga \
     -O /usr/bin/gosu \
-    https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH}${TARGETVARIANT}
+    "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH}${TARGETVARIANT}"
 chmod +x /usr/bin/gosu
 
 echo "**** Verify gosu works ****"

--- a/images/retroarch/scripts/startup.sh
+++ b/images/retroarch/scripts/startup.sh
@@ -13,7 +13,8 @@ mkdir -p "$CFG_DIR/cores/"
 cp -u /cfg/retroarch.cfg "$CFG_DIR/retroarch.cfg"
 
 # Copy pre-installed cores from the retroarch ppa
-cp -u /usr/lib/x86_64-linux-gnu/libretro/* "$CFG_DIR/cores/"
+# shellcheck disable=SC2046
+cp -u /usr/lib/$(uname -m)-linux-gnu/libretro/* "$CFG_DIR/cores/"
 
 # if there are no assets, manually download them
 if [ ! -d "$CFG_DIR/assets" ]; then

--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 ARG BASE_APP_IMAGE
 
 ######################################
@@ -6,26 +7,39 @@ FROM lizardbyte/sunshine:v0.18.1-ubuntu-22.04 AS sunshine-image
 # hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE} AS sunshine
 
+ARG TARGETARCH TARGETVARIANT
+
 ARG REQUIRED_PACKAGES="\
     libgbm1 libgles2-mesa libegl1 libgl1-mesa-dri \
     libvulkan1 \
     libvdpau1 libnuma1 \
-    i965-va-driver-shaders \
-    intel-media-va-driver-non-free \
-    libdrm-intel1 \
     libva-drm2 libva-x11-2 va-driver-all \
     libavahi-client3 \
     libcap2-bin \
     "
 
+ARG REQUIRED_PACKAGES_amd64="\
+    i965-va-driver-shaders \
+    intel-media-va-driver-non-free \
+    libdrm-intel1 \
+"
+
+ARG REQUIRED_PACKAGES_arm64="\
+"
+
 # Install using the official .deb package
 # This will take care of installing the required dependencies
 RUN \
   --mount=type=bind,from=sunshine-image,source=/sunshine.deb,target=/sunshine.deb \
-    apt-get update -y && \
-    apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
-    apt-get install -y --no-install-recommends -f /sunshine.deb && \
-    rm -rf /var/lib/apt/lists/*
+  <<_INSTALL_PACKAGES
+#!/bin/bash
+set -e
+export REQUIRED_PACKAGES_ARCH=REQUIRED_PACKAGES_${TARGETARCH}${TARGETVARIANT}
+apt-get update -y
+apt-get install -y --no-install-recommends $REQUIRED_PACKAGES ${!REQUIRED_PACKAGES_ARCH}
+apt-get install -y --no-install-recommends -f /sunshine.deb
+rm -rf /var/lib/apt/lists/*
+_INSTALL_PACKAGES
 
 # Utils for debugging
 # RUN apt-get update -y && \

--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -29,7 +29,6 @@ ARG REQUIRED_PACKAGES_arm64="\
 
 # Install using the official .deb package
 # This will take care of installing the required dependencies
-# hadolint ignore=SC2086
 RUN \
   --mount=type=bind,from=sunshine-image,source=/sunshine.deb,target=/sunshine.deb \
   <<_INSTALL_PACKAGES
@@ -37,7 +36,7 @@ RUN \
 set -e
 export REQUIRED_PACKAGES_ARCH="REQUIRED_PACKAGES_${TARGETARCH}${TARGETVARIANT}"
 apt-get update -y
-# shellcheck disable=SC2086
+# shellcheck disable=SC2086,SC3053
 apt-get install -y --no-install-recommends $REQUIRED_PACKAGES ${!REQUIRED_PACKAGES_ARCH}
 apt-get install -y --no-install-recommends -f /sunshine.deb
 rm -rf /var/lib/apt/lists/*

--- a/images/sunshine/Dockerfile
+++ b/images/sunshine/Dockerfile
@@ -29,13 +29,15 @@ ARG REQUIRED_PACKAGES_arm64="\
 
 # Install using the official .deb package
 # This will take care of installing the required dependencies
+# hadolint ignore=SC2086
 RUN \
   --mount=type=bind,from=sunshine-image,source=/sunshine.deb,target=/sunshine.deb \
   <<_INSTALL_PACKAGES
 #!/bin/bash
 set -e
-export REQUIRED_PACKAGES_ARCH=REQUIRED_PACKAGES_${TARGETARCH}${TARGETVARIANT}
+export REQUIRED_PACKAGES_ARCH="REQUIRED_PACKAGES_${TARGETARCH}${TARGETVARIANT}"
 apt-get update -y
+# shellcheck disable=SC2086
 apt-get install -y --no-install-recommends $REQUIRED_PACKAGES ${!REQUIRED_PACKAGES_ARCH}
 apt-get install -y --no-install-recommends -f /sunshine.deb
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #136. I have verified that this will install and start up cleanly on ARM (using Oracle Cloud). I have _not_ attempted to actually connect to the running Sunshine instance because I didn't want to deal with the network setup.