### PR TITLE
add: pcsx2 container

### DIFF
--- a/compose/apps/pcsx2.yml
+++ b/compose/apps/pcsx2.yml
@@ -1,0 +1,45 @@
+#########################
+# pcsx2.yml
+#########################
+#
+# This container runs PCSX2
+
+services:
+  ####################
+  pcsx2:
+    build:
+      context: ./images/pcsx2
+      args:
+        BASE_IMAGE: ${BUILD_BASE_IMAGE}
+        BASE_APP_IMAGE: ${BUILD_BASE_APP_IMAGE}
+    runtime: ${DOCKER_RUNTIME}
+    privileged: true
+    network_mode: ${UDEVD_NETWORK}
+    volumes:
+      # Followings are needed in order to get joystick support
+      - /dev/input:/dev/input:ro
+      - udev:/run/udev/:ro
+      # Xorg socket in order to get the screen
+      - ${XORG_SOCKET}:/tmp/.X11-unix
+      # Pulse socket, audio
+      - ${PULSE_SOCKET_HOST}:${PULSE_SOCKET_GUEST}
+      # Home directory: retroarch games, downloads, cores etc
+      - ${local_state}/:/home/retro/
+      # some emulators need more than 64 MB of shared memory - see https://github.com/libretro/dolphin/issues/222
+      # TODO: why shm_size doesn't work ??????
+      - type: tmpfs
+        target: /dev/shm
+        tmpfs:
+          size: ${SHM_SIZE}
+    ipc: ${SHARED_IPC}  # Needed for MIT-SHM, removing this should cause a performance hit see https://github.com/jessfraz/dockerfiles/issues/359
+    env_file:
+      - config/common.env
+      - config/xorg.env
+      # run-gow: gpu_env
+
+    environment:
+      # Which devices does GoW need to be able to use? The docker user will be
+      # added to the groups that own these devices, to help with permissions
+      # issues
+      # These values are the defaults, but you can add others if needed
+      GOW_REQUIRED_DEVICES: /dev/uinput /dev/input/event* /dev/dri/* /dev/snd/*

--- a/compose/apps/xfce.yml
+++ b/compose/apps/xfce.yml
@@ -1,0 +1,45 @@
+#########################
+# xfce4.yml
+#########################
+#
+# This container runs XFCE
+
+services:
+  ####################
+  xfce4:
+    build:
+      context: ./images/xfce
+      args:
+        BASE_IMAGE: ${BUILD_BASE_IMAGE}
+        BASE_APP_IMAGE: ${BUILD_BASE_APP_IMAGE}
+    runtime: ${DOCKER_RUNTIME}
+    privileged: true
+    network_mode: ${UDEVD_NETWORK}
+    volumes:
+      # Followings are needed in order to get joystick support
+      - /dev/input:/dev/input:ro
+      - udev:/run/udev/:ro
+      # Xorg socket in order to get the screen
+      - ${XORG_SOCKET}:/tmp/.X11-unix
+      # Pulse socket, audio
+      - ${PULSE_SOCKET_HOST}:${PULSE_SOCKET_GUEST}
+      # Home directory: retroarch games, downloads, cores etc
+      - ${local_state}/:/home/retro/
+      # some emulators need more than 64 MB of shared memory - see https://github.com/libretro/dolphin/issues/222
+      # TODO: why shm_size doesn't work ??????
+      - type: tmpfs
+        target: /dev/shm
+        tmpfs:
+          size: ${SHM_SIZE}
+    ipc: ${SHARED_IPC}  # Needed for MIT-SHM, removing this should cause a performance hit see https://github.com/jessfraz/dockerfiles/issues/359
+    env_file:
+      - config/common.env
+      - config/xorg.env
+      # run-gow: gpu_env
+
+    environment:
+      # Which devices does GoW need to be able to use? The docker user will be
+      # added to the groups that own these devices, to help with permissions
+      # issues
+      # These values are the defaults, but you can add others if needed
+      GOW_REQUIRED_DEVICES: /dev/uinput /dev/input/event* /dev/dri/* /dev/snd/*

--- a/images/pcsx2/Dockerfile
+++ b/images/pcsx2/Dockerfile
@@ -1,0 +1,25 @@
+ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
+FROM ${BASE_APP_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG REQUIRED_PACKAGES=" \
+    libvulkan1 \
+    software-properties-common \
+    "
+
+RUN apt-get update && \
+    apt-get install $REQUIRED_PACKAGES -y
+
+RUN add-apt-repository -y ppa:pcsx2-team/pcsx2-daily 
+
+RUN apt-get update && \
+    apt-get install -y pcsx2-unstable
+
+ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
+
+COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/pcsx2/scripts/startup.sh
+++ b/images/pcsx2/scripts/startup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source /opt/gow/bash-lib/utils.sh
+
+gow_log "Starting PCSX2"
+
+CFG_DIR=$HOME/.config/PCSX2
+
+exec /usr/bin/pcsx2-qt
+

--- a/images/xfce/Dockerfile
+++ b/images/xfce/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
+FROM ${BASE_APP_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG REQUIRED_PACKAGES=" \
+    "
+
+RUN apt-get update && \
+    apt-get install -y xfce4
+
+ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
+
+COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/xfce/scripts/startup.sh
+++ b/images/xfce/scripts/startup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+source /opt/gow/bash-lib/utils.sh
+
+gow_log "Starting XFCE4"
+
+CFG_DIR=$HOME/.config/xfce4/xfconf/xfce-perchannel-xml/
+
+exec xfce4-session
+


### PR DESCRIPTION
After a few days testing, I was able to get PCSX2 running with Vulkan in my host. I'll try to create a Dockerfile + script pair, next time, that could launch xfce4 and allow us to launch one more emulator at a time, without the need to stop a container and launch other in case of the need to launch another app.