### PR TITLE
feat: Add nvidia driver mappings for endeavouros

### DIFF
--- a/run-gow
+++ b/run-gow
@@ -359,6 +359,11 @@ xorg_driver[arch]=$(cat - <<END
 - /usr/lib/nvidia/xorg/libglxserver_nvidia.so:/nvidia/xorg/libglxserver_nvidia.so:ro
 END
 )
+xorg_driver[endeavouros]=$(cat - <<END
+- /usr/lib/xorg/modules/drivers/nvidia_drv.so:/nvidia/xorg/nvidia_drv.so:ro
+- /usr/lib/nvidia/xorg/libglxserver_nvidia.so:/nvidia/xorg/libglxserver_nvidia.so:ro
+END
+)
 xorg_driver[debian]=$(cat - <<END
 - /usr/lib/xorg/modules/drivers/nvidia_drv.so:/nvidia/xorg/nvidia_drv.so:ro
 - /usr/lib/xorg/modules/extensions/libglxserver_nvidia.so:/nvidia/xorg/libglxserver_nvidia.so:ro


### PR DESCRIPTION
Adds another entry to the xorg_driver mappings for endeavouros.
Same host locations as arch