### PR TITLE
fix containers using the wrong home dir

### DIFF
--- a/images/base/overlay/etc/cont-init.d/10-setup_user.sh
+++ b/images/base/overlay/etc/cont-init.d/10-setup_user.sh
@@ -10,14 +10,20 @@ if [[ "${UNAME}" != "root" ]]; then
     UMASK="${UMASK:-000}"
 
     gow_log "Setting default user uid=${PUID}(${UNAME}) gid=${PGID}(${UNAME})"
-    usermod -o -u "${PUID}" "${UNAME}"
+    if id -u "${PUID}" &>/dev/null; then
+        # need to delete the old user $PUID then change $UNAME's UID
+        oldname=$(id -nu "${PUID}")
+        userdel -r "${oldname}"
+    fi
+
+    usermod -u "${PUID}" "${UNAME}"
     groupmod -o -g "${PGID}" "${UNAME}"
 
     gow_log "Setting umask to ${UMASK}"
     umask "${UMASK}"
 
     gow_log "Ensure retro home directory is writable"
-    chown "${PUID}:${PGID}" "${HOME}" 
+    chown "${PUID}:${PGID}" "${HOME}"
 
     gow_log "Ensure XDG_RUNTIME_DIR is writable"
     chown -R "${PUID}:${PGID}" "${XDG_RUNTIME_DIR}"


### PR DESCRIPTION
by ensuring there's only one user with the preferred UID

Originally discussed in Discord:

> it happens when the container starts up and tries to change the default user's UID/PID based on the environment. basically if you use a UID that already exists (which we do by default) it ends up adding a second user with the same ID and a different $HOME. then when steam (or whatever) tries to get the home dir for its user id it gets the home dir of the older user, which in this case is wrong.  it can be fixed by actually changing the user's UID instead of creating a second user
