### PR TITLE
steam: initial startup

### DIFF
--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -31,9 +31,10 @@ ARG REQUIRED_PACKAGES=" \
     libvulkan1 libvulkan1:i386 \
     mesa-vulkan-drivers mesa-vulkan-drivers:i386 \
     libgbm1:i386 libgles2:i386 libegl1:i386 libgl1-mesa-dri:i386 libgl1:i386 libglapi-mesa:i386 libglx0:i386 \
-    libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 libfreetype6 libfreetype6:i386 \
+    libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
-    mangoapp ibus curl pkexec xz-utils zenity file \
+    mangoapp ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
+    libfontconfig1:i386 libfontconfig1:amd64 libfreetype6 libfreetype6:i386 \
 "
 
 RUN apt-get update -y && \
@@ -57,6 +58,9 @@ RUN touch /etc/NetworkManager/conf.d/10-globally-managed-devices.conf
 
 # skip annoying debian dialog
 RUN rm /usr/bin/zenity && ln -s /usr/bin/true /usr/bin/zenity
+
+# refresh system font cache. For font warnings on startup see: https://github.com/ValveSoftware/steam-runtime/issues/482
+RUN fc-cache -f -v
 
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -33,7 +33,7 @@ ARG REQUIRED_PACKAGES=" \
     libgbm1:i386 libgles2:i386 libegl1:i386 libgl1-mesa-dri:i386 libgl1:i386 libglapi-mesa:i386 libglx0:i386 \
     libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 libfreetype6 libfreetype6:i386 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
-    mangoapp ibus \
+    mangoapp ibus curl pkexec xz-utils zenity file \
 "
 
 RUN apt-get update -y && \
@@ -54,6 +54,9 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 # fix NetworkManager not picking up devices
 RUN touch /etc/NetworkManager/conf.d/10-globally-managed-devices.conf
+
+# skip annoying debian dialog
+RUN rm /usr/bin/zenity && ln -s /usr/bin/true /usr/bin/zenity
 
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -30,7 +30,7 @@ ARG REQUIRED_PACKAGES=" \
     steam \
     libvulkan1 libvulkan1:i386 \
     mesa-vulkan-drivers mesa-vulkan-drivers:i386 \
-    libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 \
+    libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
     mangoapp ibus \
 "

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -44,6 +44,9 @@ RUN apt-get update -y && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
     # \
+    # Fix steam updater UI font file \
+    ln -s /usr/share/fonts/truetype/dejavu /usr/share/fonts/truetype/ttf-dejavu && \
+    # \
     # Cleanup \
     apt-get remove -y software-properties-common && \
     apt-get autoremove -y && \

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -30,7 +30,7 @@ ARG REQUIRED_PACKAGES=" \
     steam \
     libvulkan1 libvulkan1:i386 \
     mesa-vulkan-drivers mesa-vulkan-drivers:i386 \
-    libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 \
+    libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 libfreetype6 libfreetype6:i386 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
     mangoapp ibus \
 "

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -30,6 +30,7 @@ ARG REQUIRED_PACKAGES=" \
     steam \
     libvulkan1 libvulkan1:i386 \
     mesa-vulkan-drivers mesa-vulkan-drivers:i386 \
+    libgbm1:i386 libgles2:i386 libegl1:i386 libgl1-mesa-dri:i386 libgl1:i386 libglapi-mesa:i386 libglx0:i386 \
     libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 libfreetype6 libfreetype6:i386 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
     mangoapp ibus \

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -37,7 +37,7 @@ ARG REQUIRED_PACKAGES=" \
 "
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends software-properties-common && \
+    apt-get install -y python3-six software-properties-common && \
     # \
     # Install steam (Steam is 32-bit only) \
     dpkg --add-architecture i386 && \
@@ -49,7 +49,7 @@ RUN apt-get update -y && \
     ln -s /usr/share/fonts/truetype/dejavu /usr/share/fonts/truetype/ttf-dejavu && \
     # \
     # Cleanup \
-    apt-get remove -y software-properties-common && \
+    apt-get remove -y python3-six software-properties-common && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 # fix NetworkManager not picking up devices

--- a/images/steam/scripts/startup.sh
+++ b/images/steam/scripts/startup.sh
@@ -56,9 +56,9 @@ export GTK_IM_MODULE=Steam
 
 if [ -n "$RUN_GAMESCOPE" ]; then
   # Enable support for xwayland isolation per-game in Steam
-  # Note: This breaks without these additional flags
-  export STEAM_MULTIPLE_XWAYLANDS=1
-  STEAM_STARTUP_FLAGS="${STEAM_STARTUP_FLAGS} -steamos3 -steamdeck -steampal"
+  # Note: This breaks without the additional steamdeck flags
+  #export STEAM_MULTIPLE_XWAYLANDS=1
+  #STEAM_STARTUP_FLAGS="${STEAM_STARTUP_FLAGS} -steamos3 -steamdeck -steampal"
 
   # We no longer need to set GAMESCOPE_EXTERNAL_OVERLAY from steam, mangoapp now does it itself
   export STEAM_DISABLE_MANGOAPP_ATOM_WORKAROUND=1
@@ -97,12 +97,13 @@ if [ -n "$RUN_GAMESCOPE" ]; then
   GAMESCOPE_MODE=${GAMESCOPE_MODE:-"-b"}
 
   # shellcheck disable=SC2086
-  /usr/games/gamescope ${GAMESCOPE_MODE} --steam --xwayland-count 2 -R $socket -T $stats -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" &
+  /usr/games/gamescope -e ${GAMESCOPE_MODE} -R $socket -T $stats -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" &
 
   # Read the variables we need from the socket
   if read -r -t 3 response_x_display response_wl_display <> "$socket"; then
 	export DISPLAY="$response_x_display"
 	export GAMESCOPE_WAYLAND_DISPLAY="$response_wl_display"
+	unset WAYLAND_DISPLAY
 	# We're done!
   else
 	echo "gamescope failed"


### PR DESCRIPTION
The steamdeck mode we were currently using has problems starting up with the debian packages bootstrap install.
We originally used that mode for the new UI and a bunch of steam deck specific features.
These days the desktop bigpicture mode has catched up and updates fine on initial launch.
So lets switch to that (and sadly disable the Xwayland separation from gamescope as normal steam won't use that causing black screens in games).