### PR TITLE
updated script to check for the new docker compose instead of docker-compose

### DIFF
--- a/run-gow
+++ b/run-gow
@@ -386,9 +386,9 @@ transform_file() {
 
 # return the docker compose cli executable path
 get_compose_exec_path() {
-    local docker_compose_command="$(command -v docker 2> /dev/null) compose"
-    if command -v docker-compose &> /dev/null; then
-        docker_compose_command="$(command -v docker-compose 2> /dev/null)"
+	local docker_compose_command="$(command -v docker 2> /dev/null) compose"
+    if command -v "docker compose" &> /dev/null; then
+        docker_compose_command="$(command -v docker compose 2> /dev/null)"
     fi
     echo "${docker_compose_command}"
 }


### PR DESCRIPTION
`docker-compose` is an *outdated script* so I replaced it with the compose plugin