### PR TITLE
Implement a lutris container.

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -6,6 +6,9 @@
 *** xref:how-to-use.adoc[How can I use GOW?]
 *** xref:roadmap.adoc[Roadmap]
 
+** Images
+*** xref:lutris.adoc[]
+
 ** Getting Started
 *** xref:requirements.adoc[Prerequisites]
 **** xref:monitor.adoc[Monitor requirements]

--- a/docs/modules/ROOT/pages/lutris.adoc
+++ b/docs/modules/ROOT/pages/lutris.adoc
@@ -1,0 +1,347 @@
+= Lutris
+
+The `gameonwhales/lutris` image can be used to run a veriety of applications.
+Lutris refers to its self a "preservation platform", and provides scripts for
+installing many pieces of software on linux, from many different platforms. 
+
+The software you want to run may already have an entry on the
+https://lutris.net/[Lutris website], in which case, you can either install the
+software from the Lutris UI directly or extend the image to create a bespoke
+image.
+
+
+== Internal Layout
+
+On first run, the startup scripts for this image will configure Lutris to store
+game installation files and installation meta data in the `/var/lutris` directory.
+By mounting a volume at this directory, multiple instances of the image will
+share videogame installations. Most applications will save user specific data
+in the home directory, which remains exclusively visible to the individual user. 
+
+Lutris is a desktop application that launches other windows, and as such, it
+requires a window manager to run. It and it's derivitives should be launched with
+`USE_SWAY=1`, to enable the Sway Window Manager.
+
+
+== Folder Format
+
+The following documents the file-format for images in GOW in general, as well as
+a couple of perculiars specific to the Lutris Image.
+
+The Lutris image consists of the following files;
+```
+images
+ +- lutris
+     +- Dockerfile
+     +- scripts
+     |   +- startup.sh
+     |   +- startup-10-create-dirs.sh
+     +- configs
+         +- lutris-system.yml
+         +- lutris-lutris.yml
+```
+
+At a basic level, all images based on the base image will feature a Dockerfile
+and `startup.sh` script. The Dockerfile will stage the `startup.sh` script at
+`/opt/gow/startup.sh`, overwriting the version provided by the base-app script.
+The Dockerfile will also copy all the assets for the container (usually to 
+`/opt/gow/`), and install any additional dependencies.
+
+The `startup.sh` script will at the start of every container launch. It must
+first prepare the home directory, which will be empty on first-run, and then
+launch the application. The Lutris image also features a `/opt/gow/startup.d`
+directory. Scripts placed in this directory will be sourced by the `startup.sh`
+script prior to launching Lutris.
+
+`startup-10-create-dirs.sh` is copied by the Dockerfile to `/opt/gow/startup.d`.
+It configures Lutris to install games in `/var/lutris/Games` by default, and
+allow multiple instances of the Lutris container to share installation files.
+
+== Building the Lutris Image
+
+These instructions are applicable to any image based on the GoW base image, and
+are useful if you want to make changes to the image. When making changes to
+images upon which other images are based, it is naturally required to build all
+dependent images to propergate the changes.
+
+=== Step 1. Build the base image
+
+```
+$ docker build -t gow/base images/base
+```
+
+
+=== Step 2. Build the base-app image
+
+```
+$ docker build -t gow/base-app --build-arg BASE_IMAGE=gow/base images/base-app
+```
+
+
+=== Step 3. Build the lutris image
+
+```
+$ docker build -t gow/lutris --build-arg BASE_APP_IMAGE=gow/base-app images/lutris
+```
+
+=== Step 4. Configure Wolf to use the container
+
+Place the following in `/etc/wolf/cfg/config.toml`
+```
+[[apps]]
+title = "Lutris"
+start_virtual_compositor = true
+
+[apps.runner]
+type = "docker"
+name = "WolfLutris"
+image = "gow/lutris"
+mounts = ["lutris-games:/var/lutris/:rw"]
+env = ["RUN_SWAY=1","GOW_REQUIRED_DEVICES=/dev/input/event* /dev/dri/* /dev/nvidia*"]
+devices = []
+ports = []
+base_create_json = """
+{
+  "HostConfig": {
+    "IpcMode": "host",
+    "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
+    "Privileged": false,
+    "DeviceCgroupRules": ["c 13:* rmw"]
+  }
+}
+\
+"""
+```
+
+== Extending the Lutris Image
+
+Lutris supports launching games directly, skipping its UI, by passing the correct
+command line arguments to the lutris binary. Lutris uses this feature to add
+launchers to menus and desktop shortcuts. We can use it to create a custom
+container image which uses Lutris' installation scripts, but features a single
+program. 
+
+Consider the following structure:
+
+```
+images
+ +- lutris-app
+     +- Dockerfile
+     +- scripts
+         +- startup-20-configure-lutris.sh
+```
+
+The `Dockerfile` would copy `startup-20-configure-lutris.sh` to
+`/opt/gow/startup.d/20-configure-lutris.sh`, which in turn would be picked up by
+the Lutris image's `startup.sh` script, and would adjust Lutris' commandline args
+to run the application.
+
+
+=== A Practical Example
+
+Super Tux is a Linux native game which is distributed via AppImage. It also happens
+to have a Lutris install script. To create a Super Tux image based on the Lutris
+image, replicate the above structure with the following file contents;
+
+==== Dockerfile
+```
+ARG BASE_APP_IMAGE
+
+FROM ${BASE_APP_IMAGE}
+
+COPY --chmod=777 scripts/startup-20-launch-supertux.sh /opt/gow/startup.d/20-launch-supertux.sh
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE
+```
+
+==== scripts/startup-20-launch-supertux.sh
+```
+#!/bin/bash -e
+
+gow_log "[start-launch-supertux] Begin"
+
+if $LUTRIS -lo 2>/dev/null | grep "supertux"
+then
+    gow_log "[start-launch-supertux] Super Tux is already installed! Launching."
+    LUTRIS_ARGS=("lutris:rungame/supertux")
+else
+    gow_log "[start-launch-supertux] Super Tux is not installed! Installing."
+    LUTRIS_ARGS=("lutris:supertux")
+fi
+
+gow_log "[start-launch-supertux] End"
+```
+
+==== Build the image
+Build the image based on the Lutris image with the following command;
+```
+$ docker build -t lutris-supertux --build-arg BASE_APP_IMAGE=lutris images/lutris-supertux
+```
+
+==== config.toml
+Finally, add the appropreate entry to `/etc/wolf/cfg/config.toml` to add it to wolf.
+
+```
+[[apps]]
+title = "Super Tux"
+start_virtual_compositor = true
+
+[apps.runner]
+type = "docker"
+name = "WolfSupertux"
+image = "lutris-supertux"
+mounts = ["lutris-games:/var/lutris/:rw"]
+env = ["APPIMAGE_EXTRACT_AND_RUN=1","RUN_SWAY=1","GOW_REQUIRED_DEVICES=/dev/input/event* /dev/dri/* /dev/nvidia*"]
+devices = []
+ports = []
+base_create_json = """
+{
+  "HostConfig": {
+    "IpcMode": "host",
+    "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
+    "Privileged": false,
+    "DeviceCgroupRules": ["c 13:* rmw"]
+  }
+}
+\
+"""
+```
+
+This will work. But when you run the image in wolf, you will find the game opens
+by default in windowed mode. Also, because Super Tux runs from an Appimage in
+docker, it requires the APPIMAGE_EXTRACT_AND_RUN environment variable to be set.
+
+
+=== Use a custom install script.
+
+These things can be configured in Lutris, and we can achieve the changes we
+desire by providing a customised version of Lutris' installation script.
+
+All we need to do is add the customised script to the scripts directory,
+have the Dockerfile copy it into the image, and change the startup script
+to install from the provided script.
+
+==== Structure
+```
+images
+ +- lutris-app
+     +- Dockerfile
+     +- scripts
+         +- startup-20-configure-lutris.sh
+         +- supertux-appimage.yaml
+```
+
+==== supertux-appimage.yaml
+
+This customised installation script sets `APPIMAGE_EXTRACT_AND_RUN` as an
+environment variable, and passes `--fullscreen` as a commandline argument.
+
+```
+description: ''
+game_slug: supertux
+gogslug: ''
+humblestoreid: ''
+installer_slug: supertux-appimage
+name: SuperTux
+notes: 'Arch-based systems might need to install the following dependencies: "physfs
+  glew1.10 libcurl-gnutls"'
+runner: linux
+script:
+  files:
+  - appimg: https://github.com/SuperTux/supertux/releases/download/v0.6.3/SuperTux-v0.6.3.glibc2.29-x86_64.AppImage
+  game:
+    exe: SuperTux-v0.6.3.glibc2.29-x86_64.AppImage
+    args: --fullscreen
+  installer:
+  - chmodx: appimg
+  - move:
+      dst: $GAMEDIR
+      src: appimg
+  system:
+    env:
+      APPIMAGELAUNCHER_DISABLE: true
+      APPIMAGE_EXTRACT_AND_RUN: true
+slug: supertux-appimage
+steamid: null
+version: AppImage
+year: 2003
+```
+
+==== startup-20-configure-lutris.sh
+
+The startup script is mostly the same as the previous version, except the
+installation command now points to the custom install script.
+
+```
+#!/bin/bash -e
+
+gow_log "[start-launch-supertux] Begin"
+
+if $LUTRIS -lo 2>/dev/null | grep "supertux"
+then
+    gow_log "[start-launch-supertux] Super Tux is already installed! Launching."
+    LUTRIS_ARGS=("lutris:rungame/supertux")
+else
+    gow_log "[start-launch-supertux] Super Tux is not installed! Installing."
+    LUTRIS_ARGS=("-i" "/opt/gow/supertux-appimage.yaml")
+fi
+
+gow_log "[start-launch-supertux] End"
+```
+
+==== Dockerfile
+
+The Dockerfile needs to be modified to copy the installation script to the
+right place.
+
+```
+ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
+FROM ${BASE_APP_IMAGE}
+
+COPY --chmod=777 scripts/startup-20-launch-supertux.sh /opt/gow/startup.d/20-launch-supertux.sh
+COPY scripts/supertux-appimage.yaml /opt/gow/supertux-appimage.yaml
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE
+```
+
+
+==== Build the image
+The build command is exactly the same as it was in the previous example.
+```
+$ docker build -t lutris-supertux --build-arg BASE_APP_IMAGE=lutris images/lutris-supertux
+```
+
+==== config.toml
+Finally, the appropreate entry in `/etc/wolf/cfg/config.toml` can be changed
+to remove the now superfluous environment variable.
+
+```
+[[apps]]
+title = "Super Tux"
+start_virtual_compositor = true
+
+[apps.runner]
+type = "docker"
+name = "WolfSupertux"
+image = "lutris-supertux"
+mounts = ["lutris-games:/var/lutris/:rw"]
+env = ["RUN_SWAY=1","GOW_REQUIRED_DEVICES=/dev/input/event* /dev/dri/* /dev/nvidia*"]
+devices = []
+ports = []
+base_create_json = """
+{
+  "HostConfig": {
+    "IpcMode": "host",
+    "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
+    "Privileged": false,
+    "DeviceCgroupRules": ["c 13:* rmw"]
+  }
+}
+\
+"""
+```
+

--- a/docs/modules/ROOT/pages/lutris.adoc
+++ b/docs/modules/ROOT/pages/lutris.adoc
@@ -113,6 +113,14 @@ base_create_json = """
 """
 ```
 
+Note that this configuration creates a docker named-volume called `lutris-games`
+and mounts it at `/var/lutris`. Since this is where the games will be installed,
+this may need a lot of storage space. By default, docker will store volumes in
+`/var/lib/docker/volumes`. In the above example, you can change `lutris-games` to
+any arbitrary path on the host you like, and the games data will be saved there
+instead.
+
+
 == Extending the Lutris Image
 
 Lutris supports launching games directly, skipping its UI, by passing the correct
@@ -345,3 +353,37 @@ base_create_json = """
 """
 ```
 
+==== config.toml
+
+Because the install script is now correctly setting the environment, we no
+longer have to set `APPIMAGE_EXTRACT_AND_RUN` in `config.toml`.
+
+```
+[[apps]]
+title = "Super Tux"
+start_virtual_compositor = true
+
+[apps.runner]
+type = "docker"
+name = "WolfSupertux"
+image = "lutris-supertux"
+mounts = ["lutris-games:/var/lutris/:rw"]
+env = ["RUN_SWAY=1","GOW_REQUIRED_DEVICES=/dev/input/event* /dev/dri/* /dev/nvidia*"]
+devices = []
+ports = []
+base_create_json = """
+{
+  "HostConfig": {
+    "IpcMode": "host",
+    "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
+    "Privileged": false,
+    "DeviceCgroupRules": ["c 13:* rmw"]
+  }
+}
+\
+"""
+```
+
+Now, when you select the "Super Tux" entry in Moonlight, Super Tux will
+install from the yaml script we've defined, and the game will run in
+fullscreen mode by default.

--- a/docs/modules/ROOT/pages/lutris.adoc
+++ b/docs/modules/ROOT/pages/lutris.adoc
@@ -1,35 +1,26 @@
 = Lutris
 
-The `gameonwhales/lutris` image can be used to run a veriety of applications.
-Lutris refers to its self a "preservation platform", and provides scripts for
-installing many pieces of software on linux, from many different platforms. 
+The `gameonwhales/lutris` (or `ghcr.io/games-on-whales/lutris`) image can be used to run a variety of applications. +
+Lutris refers to its self as a "preservation platform", and provides scripts for installing many pieces of software on Linux, from games to productivity software.
 
 The software you want to run may already have an entry on the
-https://lutris.net/[Lutris website], in which case, you can either install the
-software from the Lutris UI directly or extend the image to create a bespoke
-image.
-
+https://lutris.net/[Lutris website], in which case, you can either install the software from the Lutris UI directly or extend the image to create a bespoke image.
 
 == Internal Layout
 
-On first run, the startup scripts for this image will configure Lutris to store
-game installation files and installation meta data in the `/var/lutris` directory.
-By mounting a volume at this directory, multiple instances of the image will
-share videogame installations. Most applications will save user specific data
-in the home directory, which remains exclusively visible to the individual user. 
+On first run, the startup scripts for this image will configure Lutris to store game installation files and installation meta-data in the `/var/lutris` directory.
+By mounting a volume at this directory, multiple instances of the image will share videogame installations.
+Most applications will save user-specific data in the home directory, which remains exclusively visible to the individual user.
 
-Lutris is a desktop application that launches other windows, and as such, it
-requires a window manager to run. It and it's derivitives should be launched with
-`USE_SWAY=1`, to enable the Sway Window Manager.
-
+Lutris is a desktop application that launches other windows, and as such, it requires a window manager to run; we recommend enabling Sway (set the env variable `USE_SWAY=1`).
 
 == Folder Format
 
-The following documents the file-format for images in GOW in general, as well as
-a couple of perculiars specific to the Lutris Image.
+The following documents the file-format for images in GOW in general, as well as a couple of peculiar specific to the Lutris Image.
 
 The Lutris image consists of the following files;
-```
+
+....
 images
  +- lutris
      +- Dockerfile
@@ -39,55 +30,55 @@ images
      +- configs
          +- lutris-system.yml
          +- lutris-lutris.yml
-```
+....
 
-At a basic level, all images based on the base image will feature a Dockerfile
-and `startup.sh` script. The Dockerfile will stage the `startup.sh` script at
+At a basic level, all images based on the base image will feature a Dockerfile and `startup.sh` script. +
+The Dockerfile will stage the `startup.sh` script at
 `/opt/gow/startup.sh`, overwriting the version provided by the base-app script.
-The Dockerfile will also copy all the assets for the container (usually to 
+The Dockerfile will also copy all the assets for the container (usually to
 `/opt/gow/`), and install any additional dependencies.
 
-The `startup.sh` script will at the start of every container launch. It must
-first prepare the home directory, which will be empty on first-run, and then
-launch the application. The Lutris image also features a `/opt/gow/startup.d`
-directory. Scripts placed in this directory will be sourced by the `startup.sh`
+The `startup.sh` script will launch at the start of every container. +
+It must first prepare the home directory, which will be empty on first-run, and then launch the application.
+The Lutris image also features a `/opt/gow/startup.d` directory.
+Scripts placed in this directory will be sourced by the `startup.sh`
 script prior to launching Lutris.
 
 `startup-10-create-dirs.sh` is copied by the Dockerfile to `/opt/gow/startup.d`.
-It configures Lutris to install games in `/var/lutris/Games` by default, and
-allow multiple instances of the Lutris container to share installation files.
+It configures Lutris to install games in `/var/lutris/Games` by default, and allow multiple instances of the Lutris container to share installation files.
 
 == Building the Lutris Image
 
-These instructions are applicable to any image based on the GoW base image, and
-are useful if you want to make changes to the image. When making changes to
-images upon which other images are based, it is naturally required to build all
-dependent images to propergate the changes.
+These instructions are applicable to any image based on the GoW base image, and are useful if you want to make changes to the image.
+When making changes to images upon which other images are based, it is naturally required to build all dependent images to propergate the changes.
 
 === Step 1. Build the base image
 
-```
-$ docker build -t gow/base images/base
-```
-
+[source,bash]
+....
+docker build -t gow/base images/base
+....
 
 === Step 2. Build the base-app image
 
-```
-$ docker build -t gow/base-app --build-arg BASE_IMAGE=gow/base images/base-app
-```
-
+[source,bash]
+....
+docker build -t gow/base-app --build-arg BASE_IMAGE=gow/base images/base-app
+....
 
 === Step 3. Build the lutris image
 
-```
-$ docker build -t gow/lutris --build-arg BASE_APP_IMAGE=gow/base-app images/lutris
-```
+[source,bash]
+....
+docker build -t gow/lutris --build-arg BASE_APP_IMAGE=gow/base-app images/lutris
+....
 
 === Step 4. Configure Wolf to use the container
 
 Place the following in `/etc/wolf/cfg/config.toml`
-```
+
+[source, toml]
+....
 [[apps]]
 title = "Lutris"
 start_virtual_compositor = true
@@ -106,53 +97,50 @@ base_create_json = """
     "IpcMode": "host",
     "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
     "Privileged": false,
-    "DeviceCgroupRules": ["c 13:* rmw"]
+    "DeviceCgroupRules": ["c 13:* rmw", "c 244:* rmw"]
   }
 }
 \
 """
-```
+....
 
-Note that this configuration creates a docker named-volume called `lutris-games`
+NOTE: This configuration creates a docker named-volume called `lutris-games`
 and mounts it at `/var/lutris`. Since this is where the games will be installed,
 this may need a lot of storage space. By default, docker will store volumes in
 `/var/lib/docker/volumes`. In the above example, you can change `lutris-games` to
-any arbitrary path on the host you like, and the games data will be saved there
+any arbitrary path on the host you like, and the game data will be saved there
 instead.
 
 
 == Extending the Lutris Image
 
-Lutris supports launching games directly, skipping its UI, by passing the correct
-command line arguments to the lutris binary. Lutris uses this feature to add
-launchers to menus and desktop shortcuts. We can use it to create a custom
-container image which uses Lutris' installation scripts, but features a single
-program. 
+Lutris supports launching games directly, skipping its UI, by passing the correct command line arguments to the lutris binary.
+Lutris uses this feature to add launchers to menus and desktop shortcuts.
+We can use it to create a custom container image which uses Lutris' installation scripts, but features a single program.
 
 Consider the following structure:
 
-```
+....
 images
  +- lutris-app
      +- Dockerfile
      +- scripts
          +- startup-20-configure-lutris.sh
-```
+....
 
 The `Dockerfile` would copy `startup-20-configure-lutris.sh` to
-`/opt/gow/startup.d/20-configure-lutris.sh`, which in turn would be picked up by
-the Lutris image's `startup.sh` script, and would adjust Lutris' commandline args
-to run the application.
-
+`/opt/gow/startup.d/20-configure-lutris.sh`, which in turn would be picked up by the Lutris image's `startup.sh` script, and would adjust Lutris commandline args to run the application.
 
 === A Practical Example
 
-Super Tux is a Linux native game which is distributed via AppImage. It also happens
-to have a Lutris install script. To create a Super Tux image based on the Lutris
-image, replicate the above structure with the following file contents;
+Super Tux is a Linux native game which is distributed via AppImage.
+It also happens to have a Lutris install script.
+To create a Super Tux image based on the Lutris image, replicate the above structure with the following file contents;
 
 ==== Dockerfile
-```
+
+[source, dockerfile]
+....
 ARG BASE_APP_IMAGE
 
 FROM ${BASE_APP_IMAGE}
@@ -161,11 +149,15 @@ COPY --chmod=777 scripts/startup-20-launch-supertux.sh /opt/gow/startup.d/20-lau
 
 ARG IMAGE_SOURCE
 LABEL org.opencontainers.image.source $IMAGE_SOURCE
-```
+....
 
 ==== scripts/startup-20-launch-supertux.sh
-```
+
+[source, bash]
+....
 #!/bin/bash -e
+
+source /opt/gow/bash-lib/utils.sh
 
 gow_log "[start-launch-supertux] Begin"
 
@@ -179,18 +171,23 @@ else
 fi
 
 gow_log "[start-launch-supertux] End"
-```
+....
 
 ==== Build the image
+
 Build the image based on the Lutris image with the following command;
-```
-$ docker build -t lutris-supertux --build-arg BASE_APP_IMAGE=lutris images/lutris-supertux
-```
+
+[source, bash]
+....
+docker build -t lutris-supertux --build-arg BASE_APP_IMAGE=gow/lutris images/lutris-supertux
+....
 
 ==== config.toml
+
 Finally, add the appropreate entry to `/etc/wolf/cfg/config.toml` to add it to wolf.
 
-```
+[source, toml]
+....
 [[apps]]
 title = "Super Tux"
 start_virtual_compositor = true
@@ -209,43 +206,40 @@ base_create_json = """
     "IpcMode": "host",
     "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
     "Privileged": false,
-    "DeviceCgroupRules": ["c 13:* rmw"]
+    "DeviceCgroupRules": ["c 13:* rmw", "c 244:* rmw"]
   }
 }
 \
 """
-```
+....
 
-This will work. But when you run the image in wolf, you will find the game opens
-by default in windowed mode. Also, because Super Tux runs from an Appimage in
-docker, it requires the APPIMAGE_EXTRACT_AND_RUN environment variable to be set.
-
+This will work.
+But when you run the image in wolf, you will find the game open by default in windowed mode.
+Also, because Super Tux runs from an Appimage in docker, it requires the `APPIMAGE_EXTRACT_AND_RUN` environment variable to be set.
 
 === Use a custom install script.
 
-These things can be configured in Lutris, and we can achieve the changes we
-desire by providing a customised version of Lutris' installation script.
+These things can be configured in Lutris, and we can achieve the changes we desire by providing a customised version of a Lutris installation script.
 
-All we need to do is add the customised script to the scripts directory,
-have the Dockerfile copy it into the image, and change the startup script
-to install from the provided script.
+All we need to do is add the customised script to the scripts directory, have the Dockerfile copy it into the image, and change the startup script to install from the provided script.
 
 ==== Structure
-```
+
+....
 images
  +- lutris-app
      +- Dockerfile
      +- scripts
          +- startup-20-configure-lutris.sh
          +- supertux-appimage.yaml
-```
+....
 
 ==== supertux-appimage.yaml
 
-This customised installation script sets `APPIMAGE_EXTRACT_AND_RUN` as an
-environment variable, and passes `--fullscreen` as a commandline argument.
+This customised installation script sets `APPIMAGE_EXTRACT_AND_RUN` as an environment variable, and passes `--fullscreen` as a commandline argument.
 
-```
+[source, yaml]
+....
 description: ''
 game_slug: supertux
 gogslug: ''
@@ -274,15 +268,17 @@ slug: supertux-appimage
 steamid: null
 version: AppImage
 year: 2003
-```
+....
 
 ==== startup-20-configure-lutris.sh
 
-The startup script is mostly the same as the previous version, except the
-installation command now points to the custom install script.
+The startup script is mostly the same as the previous version, except the installation command now points to the custom install script.
 
-```
+[source, bash]
+....
 #!/bin/bash -e
+
+source /opt/gow/bash-lib/utils.sh
 
 gow_log "[start-launch-supertux] Begin"
 
@@ -296,14 +292,14 @@ else
 fi
 
 gow_log "[start-launch-supertux] End"
-```
+....
 
 ==== Dockerfile
 
-The Dockerfile needs to be modified to copy the installation script to the
-right place.
+The Dockerfile needs to be modified to copy the installation script to the right place.
 
-```
+[source, dockerfile]
+....
 ARG BASE_APP_IMAGE
 
 # hadolint ignore=DL3006
@@ -314,20 +310,23 @@ COPY scripts/supertux-appimage.yaml /opt/gow/supertux-appimage.yaml
 
 ARG IMAGE_SOURCE
 LABEL org.opencontainers.image.source $IMAGE_SOURCE
-```
-
+....
 
 ==== Build the image
+
 The build command is exactly the same as it was in the previous example.
-```
-$ docker build -t lutris-supertux --build-arg BASE_APP_IMAGE=lutris images/lutris-supertux
-```
+
+[source, bash]
+....
+docker build -t lutris-supertux --build-arg BASE_APP_IMAGE=gow/lutris images/lutris-supertux
+....
 
 ==== config.toml
-Finally, the appropreate entry in `/etc/wolf/cfg/config.toml` can be changed
-to remove the now superfluous environment variable.
 
-```
+Finally, the appropriate entry in `/etc/wolf/cfg/config.toml` can be changed to remove the now superfluous environment variable.
+
+[source, toml]
+....
 [[apps]]
 title = "Super Tux"
 start_virtual_compositor = true
@@ -351,14 +350,15 @@ base_create_json = """
 }
 \
 """
-```
+....
 
 ==== config.toml
 
-Because the install script is now correctly setting the environment, we no
+Because the installation script is now correctly setting the environment, we no
 longer have to set `APPIMAGE_EXTRACT_AND_RUN` in `config.toml`.
 
-```
+[source, toml]
+....
 [[apps]]
 title = "Super Tux"
 start_virtual_compositor = true
@@ -377,12 +377,12 @@ base_create_json = """
     "IpcMode": "host",
     "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
     "Privileged": false,
-    "DeviceCgroupRules": ["c 13:* rmw"]
+    "DeviceCgroupRules": ["c 13:* rmw", "c 244:* rmw"]
   }
 }
 \
 """
-```
+....
 
 Now, when you select the "Super Tux" entry in Moonlight, Super Tux will
 install from the yaml script we've defined, and the game will run in

--- a/images/base-app/scripts/launch-comp.sh
+++ b/images/base-app/scripts/launch-comp.sh
@@ -4,31 +4,30 @@ set -e
 source /opt/gow/bash-lib/utils.sh
 
 function launcher() {
-  APP_TO_LAUNCH=$1
   export GAMESCOPE_WIDTH=${GAMESCOPE_WIDTH:-1920}
   export GAMESCOPE_HEIGHT=${GAMESCOPE_HEIGHT:-1080}
   export GAMESCOPE_REFRESH=${GAMESCOPE_REFRESH:-60}
 
   if [ -n "$RUN_GAMESCOPE" ]; then
-    gow_log "[Gamescope] - Starting: ${APP_TO_LAUNCH}"
+    gow_log "[Gamescope] - Starting: \`$@\`"
 
     GAMESCOPE_MODE=${GAMESCOPE_MODE:-"-b"}
-    /usr/games/gamescope "${GAMESCOPE_MODE}" -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" -- ${APP_TO_LAUNCH}
+    /usr/games/gamescope "${GAMESCOPE_MODE}" -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" -- "$@"
   elif [ -n "$RUN_SWAY" ]; then
-    gow_log "[Sway] - Starting: ${APP_TO_LAUNCH}"
+    gow_log "[Sway] - Starting: \`$@\`"
 
     export XDG_SESSION_TYPE=wayland
     mkdir -p $HOME/.config/sway/
     cp /cfg/sway/config $HOME/.config/sway/config
-    # Modify the config file for res and to launch the ${APP_TO_LAUNCH} at the end
+    # Modify the config file for res and to launch the app at the end
     echo "output * resolution ${GAMESCOPE_WIDTH}x${GAMESCOPE_HEIGHT} position 0,0" >> $HOME/.config/sway/config
-    echo "workspace main; exec ${APP_TO_LAUNCH}" >> $HOME/.config/sway/config
+    echo "workspace main; exec $@" >> $HOME/.config/sway/config
 
     # Start sway
     dbus-run-session -- sway --unsupported-gpu
   else
-    gow_log "[exec] Starting: ${APP_TO_LAUNCH}"
+    gow_log "[exec] Starting: $@"
 
-    exec ${APP_TO_LAUNCH}
+    exec $@
   fi
 }

--- a/images/lutris/Dockerfile
+++ b/images/lutris/Dockerfile
@@ -1,0 +1,42 @@
+ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
+FROM ${BASE_APP_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# The following list of packages is informed by these articles;
+#   - https://github.com/lutris/docs/blob/master/InstallingDrivers.md
+#   - https://github.com/lutris/docs/blob/master/WineDependencies.md
+ARG REQUIRED_PACKAGES=" \
+    lutris \
+    libfreetype6:i386 \
+    libvulkan1 \
+    libvulkan1:i386 \
+    mesa-vulkan-drivers \
+    mesa-vulkan-drivers:i386 \
+    wine64 \
+    wine32 \
+    libasound2-plugins:i386 \
+    libsdl2-2.0-0:i386 \
+    libdbus-1-3:i386 \
+    libsqlite3-0:i386 \
+    "
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
+    # Cleanup \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -pm 777 /var/lutris/ && \
+    mkdir /opt/gow/startup.d/
+COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
+COPY --chmod=777 scripts/startup-10-create-dirs.sh /opt/gow/startup.d/10-create-dirs.sh
+COPY configs/lutris-system.yml /opt/gow/lutris-system.yml
+
+ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source $IMAGE_SOURCE

--- a/images/lutris/Dockerfile
+++ b/images/lutris/Dockerfile
@@ -35,6 +35,7 @@ RUN mkdir -pm 777 /var/lutris/ && \
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/startup-10-create-dirs.sh /opt/gow/startup.d/10-create-dirs.sh
 COPY configs/lutris-system.yml /opt/gow/lutris-system.yml
+COPY configs/lutris-lutris.conf /opt/gow/lutris-lutris.conf
 
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
 

--- a/images/lutris/configs/lutris-lutris.conf
+++ b/images/lutris/configs/lutris-lutris.conf
@@ -1,0 +1,2 @@
+[lutris]
+hide-wine-systemwide-install-warning = True

--- a/images/lutris/configs/lutris-system.yml
+++ b/images/lutris/configs/lutris-system.yml
@@ -1,0 +1,2 @@
+system:
+  game_path: /var/lutris/Games

--- a/images/lutris/scripts/startup-10-create-dirs.sh
+++ b/images/lutris/scripts/startup-10-create-dirs.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# Create the basic file structe lutris expects, using symlinks to /var/lutris
+# It is expected that a volume be mounted at /var/volume such that game
+# installation can be shared by multiple images and containers.
+
+gow_log "[start-create-dirs] Begin"
+
+# "library" will contain information about available games and installed games.
+if [ ! -d "/var/lutris/library" ]
+then
+    gow_log "[start-create-dirs] Creating /var/lutris/library"
+    mkdir -p "/var/lutris/library"
+fi
+
+if [ ! -e "${HOME}/.config/lutris/games" ]
+then
+    gow_log "[start-create-dirs] Creating symlink ${HOME}/.config/lutris/games -> /var/lutris/library"
+    mkdir -p "${HOME}/.config/lutris"
+    ln -s "/var/lutris/library" "${HOME}/.config/lutris/games"
+fi
+
+# "share" contains stateful information, and sharing share allows the system to have a common games library.
+if [ ! -d "/var/lutris/share" ]
+then
+    gow_log "[start-create-dirs] Creating /var/lutris/share"
+    mkdir -p "/var/lutris/share"
+fi
+
+if [ ! -e "${HOME}/.local/share/lutris" ]
+then
+    gow_log "[start-create-dirs] Creating symlink ${HOME}/.local/share/lutris -> /var/lutris/share"
+    mkdir -p "${HOME}/.local/share"
+    ln -s "/var/lutris/share" "${HOME}/.local/share/lutris"
+fi
+
+# "Games" will contain actual installation files.
+if [ ! -d "/var/lutris/Games" ]
+then
+    gow_log "[start-create-dirs] Creating /var/lutris/Games"
+    mkdir -p "/var/lutris/Games"
+fi
+
+# configuration file, pointing lutris at the Games directory.
+if [ ! -f "${HOME}/.config/lutris/system.yml" ]
+then
+    gow_log "[start-create-dirs] Creating lutris system config file."
+    cp "/opt/gow/lutris-system.yml" "${HOME}/.config/lutris/system.yml"
+fi
+
+gow_log "[start-create-dirs] End"

--- a/images/lutris/scripts/startup-10-create-dirs.sh
+++ b/images/lutris/scripts/startup-10-create-dirs.sh
@@ -48,4 +48,11 @@ then
     cp "/opt/gow/lutris-system.yml" "${HOME}/.config/lutris/system.yml"
 fi
 
+# configuration file, telling lutris to ignore missing wine
+if [ ! -f "${HOME}/.config/lutris/lutris.conf" ]
+then
+    gow_log "[start-create-dirs] Creating lutris config file."
+    cp "/opt/gow/lutris-lutris.conf" "${HOME}/.config/lutris/lutris.conf"
+fi
+
 gow_log "[start-create-dirs] End"

--- a/images/lutris/scripts/startup.sh
+++ b/images/lutris/scripts/startup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+source /opt/gow/bash-lib/utils.sh
+
+LUTRIS=/usr/games/lutris
+
+# Run additional startup scripts
+for file in /opt/gow/startup.d/* ; do
+    if [ -f "$file" ] ; then
+        gow_log "[start] Sourcing $file"
+        source $file
+    fi
+done
+
+gow_log "[start] Starting Lutris"
+
+source /opt/gow/launch-comp.sh
+launcher "${LUTRIS}" "${LUTRIS_ARGS[@]}"


### PR DESCRIPTION
This PR would add a new container image for lutris.

Lutris contains a mechanism to install software via yaml scripts. This PR leverages this feature to enable the creation of images specialised for specific applications. (see lutris-supertux for an example).

I've moved several key lutris directories into /var/lutris/, this is to make it possible for multiple containers to share the same set of installation files. 

I've also changed the launcher script in the base-app image to be able to specify command-line arguments to the application to be launched.

suggested wolf config.toml snippet;
```toml
[[apps]]
title = "Lutris"
start_virtual_compositor = true

[apps.runner]
type = "docker"
name = "WolfLutris"
image = "gow/lutris"
mounts = ["lutris-games:/var/lutris/:rw"] # Adjust this based on your system
env = ["RUN_SWAY=1","GOW_REQUIRED_DEVICES=/var/lutris/ /dev/input/event* /dev/dri/* /dev/nvidia*"]
devices = []
ports = []
base_create_json = """
{
  "HostConfig": {
    "IpcMode": "host",
    "CapAdd": ["NET_RAW", "MKNOD", "NET_ADMIN", "SYS_ADMIN", "SYS_NICE"],
    "Privileged": false,
    "DeviceCgroupRules": ["c 13:* rmw", "c 244:* rmw"]
  }
}
\
"""
```