### PR TITLE
Replace "Meta" key with "ALT"

### DIFF
--- a/images/base-app/configs/sway/config
+++ b/images/base-app/configs/sway/config
@@ -7,7 +7,7 @@
 ### Variables
 #
 # Logo key. Use Mod1 for Alt.
-set $mod Mod4
+set $mod Mod1
 # Home row direction keys, like vim
 set $left h
 set $down j


### PR DESCRIPTION
Meta key requires a setting change in moonlight client to properly work, ALT can works OOTB