### PR TITLE
Install the `locales` package in the steam image and generate en_US.UTF-8

### DIFF
--- a/images/base-app/Dockerfile
+++ b/images/base-app/Dockerfile
@@ -48,12 +48,18 @@ ARG REQUIRED_PACKAGES="\
     mesa-vulkan-drivers libgbm1 libgles2 libegl1 libgl1-mesa-dri \
     libnvidia-egl-wayland1 libnvidia-egl-gbm1 \
     fonts-noto-cjk \
+    locales \
     "
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     $REQUIRED_PACKAGES && \
     rm -rf /var/lib/apt/lists/*
+
+# Some games with native Linux ports require en_US.UTF-8
+# to be generated regardless of user locale settings
+# see: https://github.com/games-on-whales/gow/pull/185
+RUN locale-gen en_US.UTF-8
 
 #################################
 # GAMESCOPE

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -49,6 +49,7 @@ ARG REQUIRED_PACKAGES=" \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
     mangoapp ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
     libfontconfig1:i386 libfontconfig1:amd64 libfreetype6 libfreetype6:i386 \
+    locales \
 "
 
 RUN apt-get update -y && \
@@ -75,6 +76,10 @@ RUN rm /usr/bin/zenity && ln -s /usr/bin/true /usr/bin/zenity
 
 # refresh system font cache. For font warnings on startup see: https://github.com/ValveSoftware/steam-runtime/issues/482
 RUN fc-cache -f -v
+
+# Some games with native Linux ports require en_US.UTF-8
+# to be generated regardless of user locale settings
+RUN locale-gen en_US.UTF-8
 
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -49,7 +49,6 @@ ARG REQUIRED_PACKAGES=" \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
     mangoapp ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
     libfontconfig1:i386 libfontconfig1:amd64 libfreetype6 libfreetype6:i386 \
-    locales \
 "
 
 RUN apt-get update -y && \
@@ -76,10 +75,6 @@ RUN rm /usr/bin/zenity && ln -s /usr/bin/true /usr/bin/zenity
 
 # refresh system font cache. For font warnings on startup see: https://github.com/ValveSoftware/steam-runtime/issues/482
 RUN fc-cache -f -v
-
-# Some games with native Linux ports require en_US.UTF-8
-# to be generated regardless of user locale settings
-RUN locale-gen en_US.UTF-8
 
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh


### PR DESCRIPTION
Some games with native Linux ports (like Half-Life 2: Deathmatch) seem to require `en_US.UTF-8` locale to be available regardless of the user's language setting:

![image](https://github.com/user-attachments/assets/92856909-03b2-47d9-a136-0770f3a5f972)

This makes docker generate that locale at image build time, and leaves the `locales` package installed so the user can generate any others required.