### PR TITLE
feat: Add MangoHud support to Steam images running Sway

### DIFF
--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -47,7 +47,8 @@ ARG REQUIRED_PACKAGES=" \
     libgbm1:i386 libgles2:i386 libegl1:i386 libgl1-mesa-dri:i386 libgl1:i386 libglapi-mesa:i386 libglx0:i386 \
     libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
-    mangoapp ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
+    mangoapp mangohud \
+    ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
     libfontconfig1:i386 libfontconfig1:amd64 libfreetype6 libfreetype6:i386 \
 "
 

--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -47,8 +47,7 @@ ARG REQUIRED_PACKAGES=" \
     libgbm1:i386 libgles2:i386 libegl1:i386 libgl1-mesa-dri:i386 libgl1:i386 libglapi-mesa:i386 libglx0:i386 \
     libdbus-1-3 libgtk-3-0 libegl1 libsdl2-2.0-0 libcurl4 libcurl4:i386 \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
-    mangoapp mangohud \
-    ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
+    mangoapp ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils lsof pciutils lsb-release mesa-utils \
     libfontconfig1:i386 libfontconfig1:amd64 libfreetype6 libfreetype6:i386 \
 "
 

--- a/images/steam/scripts/startup.sh
+++ b/images/steam/scripts/startup.sh
@@ -34,6 +34,7 @@ export WINEDLLOVERRIDES=dxgi=n
 # so we don't get mangoapp showing up before Steam initializes
 # on OOBE and stuff.
 mkdir -p "$(dirname "$MANGOHUD_CONFIGFILE")"
+echo "position=top-right" > "$MANGOHUD_CONFIGFILE"
 echo "no_display" > "$MANGOHUD_CONFIGFILE"
 
 # Prepare our initial VRS config file
@@ -123,7 +124,8 @@ elif [ -n "$RUN_SWAY" ]; then
   # Start IBus to enable showing the steam on-screen keyboard
   /usr/bin/ibus-daemon -d -r --panel=disable --emoji-extension=disable
 
-  # Enable MangoHud unless it's been explicitly disabled
+  # Enable MangoHud for all vulkan (including Proton) games
+  # unless the user has explicitly disabled it in config.
   export MANGOHUD=${MANGOHUD:-1}
 
   # Start Steam

--- a/images/steam/scripts/startup.sh
+++ b/images/steam/scripts/startup.sh
@@ -123,6 +123,9 @@ elif [ -n "$RUN_SWAY" ]; then
   # Start IBus to enable showing the steam on-screen keyboard
   /usr/bin/ibus-daemon -d -r --panel=disable --emoji-extension=disable
 
+  # Enable MangoHud unless it's been explicitly disabled
+  export MANGOHUD=${MANGOHUD:-1}
+
   # Start Steam
   source /opt/gow/launch-comp.sh
   launcher /usr/games/steam ${STEAM_STARTUP_FLAGS}


### PR DESCRIPTION
Since Mangoapp is already running in Gamescope, I figured [MangoHud](https://github.com/flightlessmango/MangoHud/) makes sense for Sway.

I have no idea *where* to document this. The current Wolf documenation doesn't mention MangoApp anywhere.

But in order for this to be useful, users need to know to press `Right Shift + F12` to make the overlay show up, and `Right Shift + F11` to change the position of the overlay (shows up in the top left by default).