### PR TITLE
Make gamescope's "Switch To Desktop" quit steam

### DIFF
--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -80,6 +80,7 @@ COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh
 COPY --chmod=777 steamos-update /usr/bin/steamos-update
 COPY --chmod=777 steamos-update /usr/bin/steamos-polkit-helpers/steamos-update
+COPY --chmod=777 steamos-session-select /usr/bin/steamos-session-select
 COPY --chmod=777 jupiter-biosupdate /usr/bin/jupiter-biosupdate
 COPY --chmod=777 jupiter-biosupdate /usr/bin/steamos-polkit-helpers/jupiter-biosupdate
 COPY --from=bwrap-builder --chmod=755 /root/bubblewrap/_builddir/bwrap /usr/bin/bwrap

--- a/images/steam/steamos-session-select
+++ b/images/steam/steamos-session-select
@@ -1,1 +1,3 @@
+#!/bin/bash
+# see https://github.com/games-on-whales/gow/pull/187
 /usr/games/steam -shutdown

--- a/images/steam/steamos-session-select
+++ b/images/steam/steamos-session-select
@@ -1,0 +1,1 @@
+/usr/games/steam -shutdown


### PR DESCRIPTION
The "Exit Steam" button disappears when running in gamescope, so this is the only way I can think of to quit properly.