### PR TITLE
Added prismlauncher as an image

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -29,15 +29,16 @@ jobs:
     strategy:
       matrix:
         image:
-          - { name: xorg,       platforms: "linux/amd64" }
-          - { name: pulseaudio, platforms: "linux/amd64" }
-          - { name: udevd,      platforms: "linux/amd64" }
-          - { name: sunshine,   platforms: "linux/amd64" }
-          - { name: retroarch,  platforms: "linux/amd64" }
-          - { name: firefox,    platforms: "linux/amd64" }
-          - { name: steam,      platforms: "linux/amd64" }
-          - { name: pegasus,    platforms: "linux/amd64" }
-          - { name: lutris,     platforms: "linux/amd64" }
+          - { name: xorg,          platforms: "linux/amd64" }
+          - { name: pulseaudio,    platforms: "linux/amd64" }
+          - { name: udevd,         platforms: "linux/amd64" }
+          - { name: sunshine,      platforms: "linux/amd64" }
+          - { name: retroarch,     platforms: "linux/amd64" }
+          - { name: firefox,       platforms: "linux/amd64" }
+          - { name: steam,         platforms: "linux/amd64" }
+          - { name: pegasus,       platforms: "linux/amd64" }
+          - { name: lutris,        platforms: "linux/amd64" }
+          - { name: prismlauncher, platforms: "linux/amd64" }
         #- { name: es-de,      platforms: "linux/amd64" }
       fail-fast: false
     uses: ./.github/workflows/docker-build-and-publish.yml

--- a/images/prismlauncher/Dockerfile
+++ b/images/prismlauncher/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_APP_IMAGE
+
+# hadolint ignore=DL3006
+FROM ${BASE_APP_IMAGE}
+
+# install all needed java runtimes.
+ARG REQUIRED_PACKAGES=" \
+    openjdk-21-jre \
+    openjdk-17-jre \
+    openjdk-8-jre \
+    lsb-release \
+    wget \
+    gnupg2 \
+    "
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
+    # Get PrismLauncher from makedeb \
+    wget -qO - "https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub" | gpg --dearmor | tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | tee /etc/apt/sources.list.d/prebuilt-mpr.list && \
+    apt update && \
+    apt install -y prismlauncher && \
+    # Cleanup \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* 
+
+COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
+
+ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
+
+ARG IMAGE_SOURCE
+LABEL org.opencontainers.image.source=$IMAGE_SOURCE

--- a/images/prismlauncher/scripts/startup.sh
+++ b/images/prismlauncher/scripts/startup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+source /opt/gow/bash-lib/utils.sh
+
+PrismLauncher=prismlauncher
+
+# Run additional startup scripts
+for file in /opt/gow/startup.d/* ; do
+    if [ -f "$file" ] ; then
+        gow_log "[start] Sourcing $file"
+        source $file
+    fi
+done
+
+gow_log "[start] Starting PrismLauncher"
+
+source /opt/gow/launch-comp.sh
+launcher "${PrismLauncher}"


### PR DESCRIPTION
I included a fully functional PrismLauncher image that supports all Java versions used by Minecraft, ensuring compatibility with every version from Alpha to the latest 1.21.

Note: Since the image doesn't include a browser, you'll need to use another device, like a phone, to connect to your Microsoft account. However, this should only be necessary the first time you connect, as everything appears to save correctly afterward.

I'm successfully running Minecraft 1.21 with shaders on a 3060 Ti using proprietary drivers.

https://github.com/user-attachments/assets/478aef23-4814-4135-8cc4-5854540df8bb
