### PR TITLE
Integrating chrome browser into Steam image to extend its usefulness

### DIFF
--- a/images/steam/Dockerfile
+++ b/images/steam/Dockerfile
@@ -42,6 +42,7 @@ _FIX_LIBC6
 
 ARG REQUIRED_PACKAGES=" \
     steam \
+    sudo vim unzip\
     libvulkan1 libvulkan1:i386 \
     mesa-vulkan-drivers mesa-vulkan-drivers:i386 \
     libgbm1:i386 libgles2:i386 libegl1:i386 libgl1-mesa-dri:i386 libgl1:i386 libglapi-mesa:i386 libglx0:i386 \
@@ -63,6 +64,10 @@ RUN apt-get update -y && \
     # Fix steam updater UI font file \
     ln -s /usr/share/fonts/truetype/dejavu /usr/share/fonts/truetype/ttf-dejavu && \
     # \
+    # Install Google Chrome \
+    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    apt install ./google-chrome-stable_current_amd64.deb -y --no-install-recommends && \
+    rm ./google-chrome-stable_current_amd64.deb && \
     # Cleanup \
     apt-get remove -y python3-six software-properties-common && \
     apt-get autoremove -y && \
@@ -76,6 +81,10 @@ RUN rm /usr/bin/zenity && ln -s /usr/bin/true /usr/bin/zenity
 # refresh system font cache. For font warnings on startup see: https://github.com/ValveSoftware/steam-runtime/issues/482
 RUN fc-cache -f -v
 
+# set root password
+RUN echo "root:retro" | chpasswd
+
+COPY --chmod=777 configs/waybar/config.jsonc /cfg/waybar/config.jsonc
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh
 COPY --chmod=777 steamos-update /usr/bin/steamos-update

--- a/images/steam/configs/waybar/config.jsonc
+++ b/images/steam/configs/waybar/config.jsonc
@@ -1,0 +1,112 @@
+// -*- mode: jsonc -*-
+{
+  "layer": "top", // Waybar at top layer
+  "position": "top", // Waybar position (top|bottom|left|right)
+  "height": 30, // Waybar height (to be removed for auto height)
+  // "width": 1280, // Waybar width
+  "spacing": 4, // Gaps between modules (4px)
+  // Choose the order of the modules
+  "modules-left": [
+    "sway/workspaces",
+    "sway/mode",
+    "sway/scratchpad",
+    "custom/kitty",
+    "custom/steam",
+    "custom/chrome"
+  ],
+  "modules-center": [
+    "sway/window"
+  ],
+  "modules-right": [
+    "pulseaudio",
+    "network",
+    "cpu",
+    "memory",
+    "temperature",
+    "sway/language",
+    "clock"
+  ],
+  "custom/kitty": {
+    "format": "{} ",
+    "tooltip": false,
+    "on-click": "kitty"
+  },
+  "custom/chrome": {
+    "format": "<u>google</u>",
+    "tooltip": false,
+    "on-click": "google-chrome-stable"
+  },
+  "custom/steam": {
+    "format": "<u>steam</u>",
+    "tooltip": false,
+    "on-click": "/usr/games/steam"
+  },
+  "sway/mode": {
+    "format": "<span style=\"italic\">{}</span>"
+  },
+  "sway/scratchpad": {
+    "format": "{icon} {count}",
+    "show-empty": false,
+    "format-icons": ["", ""],
+    "tooltip": true,
+    "tooltip-format": "{app}: {title}"
+  },
+  "idle_inhibitor": {
+    "format": "{icon}",
+    "format-icons": {
+      "activated": "",
+      "deactivated": ""
+    }
+  },
+  "tray": {
+    // "icon-size": 21,
+    "spacing": 10
+  },
+  "clock": {
+    // "timezone": "America/New_York",
+    "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>",
+    "format-alt": "{:%Y-%m-%d}"
+  },
+  "cpu": {
+    "format": "{usage}% ",
+    "tooltip": false
+  },
+  "memory": {
+    "format": "{}% "
+  },
+  "temperature": {
+    // "thermal-zone": 2,
+    // "hwmon-path": "/sys/class/hwmon/hwmon2/temp1_input",
+    "critical-threshold": 80,
+    // "format-critical": "{temperatureC}°C {icon}",
+    "format": "{temperatureC}°C",
+    "format-icons": ["", "", ""]
+  },
+"network": {
+    // "interface": "wlp2*", // (Optional) To force the use of this interface
+    "format-wifi": "{essid} ({signalStrength}%) ",
+    "format-ethernet": "{ipaddr}/{cidr}",
+    "tooltip-format": "{ifname} via {gwaddr}",
+    "format-linked": "{ifname} (No IP)",
+    "format-disconnected": "Disconnected ⚠",
+    "format-alt": "{ifname}: {ipaddr}/{cidr}"
+  },
+  "pulseaudio": {
+    // "scroll-step": 1, // %, can be a float
+    "format": "{volume}% {icon} {format_source}",
+    "format-bluetooth": "{volume}% {icon} {format_source}",
+    "format-bluetooth-muted": " {icon} {format_source}",
+    "format-muted": " {format_source}",
+    "format-source": "{volume}% ",
+    "format-source-muted": "",
+    "format-icons": {
+      "headphone": "",
+      "hands-free": "",
+      "headset": "",
+      "phone": "",
+      "portable": "",
+      "car": "",
+      "default": ["", "", ""]
+    }
+  }
+}


### PR DESCRIPTION
It can be used as a simple Linux desktop environment. You can watch videos and download files through the browser. By utilizing the built-in Wine functionality of Steam, we can even download and run some Windows programs. (I chose Chrome over Firefox app image because the firefox docker image don't support HTML5 and I don't know how to fix it , and I opted for Chrome instead of Chromium due to the simpler installation process (avoid using snap)

By configuring Waybar to add custom applications, we can create a launcher similar to a desktop environment. We can open and close Steam, Kitty (terminal), and Chrome at any time. check example [waybar](https://github.com/games-on-whales/gow/blob/4c4ca4f004c1f0a5694fc1c236460cc60902aa99/images/base-app/configs/waybar/config.jsonc#L27-L31) configuration
![image](https://github.com/user-attachments/assets/b167ccf0-ab16-43ea-8db8-35df7bb62e17)

Hope this pull request here can help someone like me.
