### PR TITLE
Added winetricks and zenity packages to Lutris image

### DIFF
--- a/images/lutris/Dockerfile
+++ b/images/lutris/Dockerfile
@@ -22,6 +22,8 @@ ARG REQUIRED_PACKAGES=" \
     libdbus-1-3:i386 \
     libsqlite3-0:i386 \
     wine-stable \
+    winetricks \
+    zenity \
     "
 
 RUN dpkg --add-architecture i386 && \


### PR DESCRIPTION
To be able to use winetricks within Lutris image there are two packages needed:

- winetricks
- zenity

This PR include both packages in the Lutris image Dockerfile