### PR TITLE
add libavcodec-extra and ubuntu-restricted-extras for firefox

### DIFF
--- a/images/firefox/Dockerfile
+++ b/images/firefox/Dockerfile
@@ -8,6 +8,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG REQUIRED_PACKAGES=" \
     libpci3 \
     firefox \
+    libavcodec-extra \
+    ubuntu-restricted-extras \
 "
 
 COPY <<_APT_PIN /etc/apt/preferences.d/mozilla-firefox


### PR DESCRIPTION
this is needed to play DRM content (only tested on Netflix) 