### PR TITLE
Startup flags variable for Heroic Launcher

### DIFF
--- a/images/heroic-games-launcher/scripts/startup.sh
+++ b/images/heroic-games-launcher/scripts/startup.sh
@@ -2,4 +2,4 @@
 set -e
 
 source /opt/gow/launch-comp.sh
-launcher /usr/bin/heroic --no-sandbox
+launcher /usr/bin/heroic ${HEROIC_STARTUP_FLAGS} --no-sandbox


### PR DESCRIPTION
Proposal of adding startup flags variable for Heroic Launcher. Tested and working.

Startup flags are needed when you want to automatically start a game like this from config.toml:
```
[[apps]]
start_virtual_compositor = true
title = "Desperados III"

[apps.runner]
base_create_json = """
{
  "HostConfig": {
    "IpcMode": "host",
    "CapAdd": ["SYS_ADMIN", "SYS_NICE", "SYS_PTRACE", "NET_RAW", "MKNOD", "NET_ADMIN"],
    "SecurityOpt": ["seccomp=unconfined", "apparmor=unconfined"],
    "Ulimits": [{"Name":"nofile", "Hard":10240, "Soft":10240}],
    "Privileged": false,
    "DeviceCgroupRules": ["c 13:* rmw", "c 244:* rmw"]
  }
}
"""
ports = []
devices = []
env = [
  "PROTON_LOG=1",
  "RUN_SWAY=true",
  "TZ=Europe/Warsaw",
  "GOW_REQUIRED_DEVICES=/dev/input/* /dev/dri/* /dev/nvidia*",
  "HEROIC_STARTUP_FLAGS=heroic://launch/legendary/90f2d13d11e74ef29ac1af5c8b0b7730",
]
mounts = []
image = "gowhgl:edge"
name = "WolfSteam"
type = "docker"
```