### PR TITLE
RetroArch LRPS2 core missing dependencies

### DIFF
--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
     # Cleanup \
     apt-get remove -y software-properties-common gpg-agent && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
+    ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
 
 COPY configs/retroarch.cfg /cfg/retroarch.cfg
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh

--- a/images/retroarch/Dockerfile
+++ b/images/retroarch/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     add-apt-repository ppa:libretro/stable && \
     apt-get update && \
     # Install retroarch \
-    apt-get install -y retroarch p7zip-full && \
+    apt-get install -y retroarch p7zip-full libglu1 libaio1t64 && \
     # Cleanup \
     apt-get remove -y software-properties-common gpg-agent && \
     apt-get autoremove -y && \


### PR DESCRIPTION
#195 details missing dependencies when trying to launch the LRPS2 core in the RetroArch image.
Log line that points to the issue:
```
[ERROR] Failed to open libretro core: "/home/retro/.config/retroarch/cores/pcsx2_libretro.so"
[ERROR] Error(s): libGLU.so.1: cannot open shared object file: No such file or directory
```
The missing dependencies can be checked and confirmed by running `ldd ~/.config/retroarch/cores/pcsx2_libretro.so`, which reveals the following in it's output:
```
libGLU.so.1 => not found
libaio.so.1 => not found
```
This PR installs `libglu1` and `libaio1t64`, and creates a symbolic link of `libaio.so.1t64` as `libaio.so.1`, thus resolving the missing dependencies.