### PR TITLE
Kodi image via Flatpak

### DIFF
--- a/images/kodi/Dockerfile
+++ b/images/kodi/Dockerfile
@@ -1,65 +1,27 @@
+# syntax=docker/dockerfile:1.4
 ARG BASE_APP_IMAGE
 
 # hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE}
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-# TODO: Build this madness in a multi-step Dockerfile and just copy the needed binary
-# Required packages are listed here:
-# - https://github.com/xbmc/xbmc/blob/master/docs/README.Ubuntu.md#32-get-build-dependencies-manually
-ARG REQUIRED_PACKAGES=" \
-    debhelper autoconf autoconf automake \
-    autopoint gettext autotools-dev cmake \
-    curl default-jre doxygen gawk gcc gdc \
-    gperf libasound2-dev libass-dev \
-    libavahi-client-dev libavahi-common-dev \
-    libbluetooth-dev libbluray-dev libbz2-dev \
-    libcdio-dev libp8-platform-dev libcrossguid-dev \
-    libcurl4-openssl-dev libcwiid-dev libdbus-1-dev \
-    libdrm-dev libegl1-mesa-dev libenca-dev \
-    libexiv2-dev libflac-dev libfmt-dev \
-    libfontconfig-dev libfreetype6-dev \
-    libfribidi-dev libfstrcmp-dev \
-    libgcrypt-dev libgif-dev libgles2-mesa-dev \
-    libgl1-mesa-dev libglu1-mesa-dev libgnutls28-dev \
-    libgpg-error-dev libgtest-dev libiso9660-dev \
-    libjpeg-dev liblcms2-dev libltdl-dev liblzo2-dev \
-    libmicrohttpd-dev libmysqlclient-dev libnfs-dev \
-    libogg-dev libpcre2-dev libplist-dev libpng-dev \
-    libpulse-dev libshairplay-dev libsmbclient-dev \
-    libspdlog-dev libsqlite3-dev libssl-dev libtag1-dev \
-    libtiff5-dev libtinyxml-dev libtinyxml2-dev libtool \
-    libudev-dev libunistring-dev libva-dev libvdpau-dev \
-    libvorbis-dev libxmu-dev libxrandr-dev libxslt1-dev \
-    libxt-dev lsb-release meson nasm ninja-build \
-    python3-dev python3-pil python3-pip rapidjson-dev \
-    swig unzip uuid-dev zip zlib1g-dev git \
-    libflatbuffers-dev libglew-dev libwayland-dev \
-    libxkbcommon-dev waylandpp-dev wayland-protocols \
+ARG CORE_PACKAGES=" \
+    kodi \
+    kodi-peripheral-joystick \
+    kodi-pvr-* \
     "
 
-# Build Kodi from source
-RUN apt-get update && \
-    apt-get install -y $REQUIRED_PACKAGES && \
-    git clone https://github.com/xbmc/xbmc kodi && \
+RUN \
+    # \
     apt-get update && \
-    mkdir kodi-build && \
-    cd kodi-build && \
-    cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DCORE_PLATFORM_NAME=wayland -DAPP_RENDER_SYSTEM=gl && \
-    cmake --build . -- VERBOSE=1 -j$(getconf _NPROCESSORS_ONLN) && \
-    make install
+    # \
+    # Install core packages \
+    apt-get install -y --no-install-recommends $CORE_PACKAGES && \
+    # \
+    apt-get autoremove -y &&\
+    apt-get clean
 
-# Build controller addon; !!! Add needed Addons HERE !!!
-RUN cd kodi && \
-    make -j$(getconf _NPROCESSORS_ONLN) -C tools/depends/target/binary-addons PREFIX=/usr/local && \
-    #clean up
-    cd .. && \
-    rm -R kodi/ && \
-    rm -R kodi-build/ && \
-    apt-get autoremove -y --purge
-
-
+# 
+# Replace launch scripts
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/startup-10-create-dirs.sh /opt/gow/startup.d/10-create-dirs.sh
 COPY configs/Xbox_controller.xml /opt/gow/Xbox_controller.xml

--- a/images/kodi/Dockerfile
+++ b/images/kodi/Dockerfile
@@ -5,9 +5,7 @@ ARG BASE_APP_IMAGE
 FROM ${BASE_APP_IMAGE}
 
 ARG CORE_PACKAGES=" \
-    kodi \
-    kodi-peripheral-joystick \
-    kodi-pvr-* \
+    flatpak \
     "
 
 RUN \
@@ -17,8 +15,21 @@ RUN \
     # Install core packages \
     apt-get install -y --no-install-recommends $CORE_PACKAGES && \
     # \
+    # Clean \
+    apt-get update && \
+    apt-get remove -y \
+	foot && \
     apt-get autoremove -y &&\
-    apt-get clean
+    apt-get clean && \
+    rm -rf \
+        /config/.cache \
+        /var/lib/apt/lists/* \
+        /var/tmp/* \
+        /tmp/*
+
+# 
+# Fix bwarp perms for flatpaks
+RUN chmod u+s /usr/bin/bwrap
 
 # 
 # Replace launch scripts

--- a/images/kodi/Dockerfile
+++ b/images/kodi/Dockerfile
@@ -9,33 +9,42 @@ ARG CORE_PACKAGES=" \
     flatpak \
     "
 
-RUN \
-    # \
-    apt-get update && \
-    # \
-    # Install core packages \
-    apt-get install -y --no-install-recommends $CORE_PACKAGES && \
-    # \
-    # Clean \
-    apt-get update && \
-    apt-get remove -y \
-	foot && \
-    apt-get autoremove -y &&\
-    apt-get clean && \
-    rm -rf \
-        /config/.cache \
-        /var/lib/apt/lists/* \
-        /var/tmp/* \
-        /tmp/*
+RUN <<_INSTALL_FLATPAK
+
+apt-get update
+# Install core packages
+apt-get install -y --no-install-recommends $CORE_PACKAGES
+# Clean
+apt-get update
+apt-get remove -y foot
+apt-get autoremove -y
+apt-get clean
+rm -rf \
+    /config/.cache \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
+    /tmp/*
+
+_INSTALL_FLATPAK
 
 # 
 # Fix bwarp perms for flatpaks
 RUN chmod u+s /usr/bin/bwrap
 
-COPY overlay /
+#
+# System wide install of Kodi
+RUN <<_INSTALL_KODI
+
+service dbus start
+flatpak remote-add --system --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install -y --noninteractive --system tv.kodi.Kodi
+flatpak override --system tv.kodi.Kodi --filesystem=home
+
+_INSTALL_KODI
 
 # 
 # Replace launch scripts
+COPY overlay /
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/startup-10-create-dirs.sh /opt/gow/startup.d/10-create-dirs.sh
 COPY configs/Xbox_controller.xml /opt/gow/Xbox_controller.xml

--- a/images/kodi/Dockerfile
+++ b/images/kodi/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG BASE_APP_IMAGE
+ARG BASE_APP_IMAGE=ghcr.io/games-on-whales/base-app:edge
 
 # hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE}
@@ -9,7 +9,7 @@ ARG CORE_PACKAGES=" \
     flatpak \
     "
 
-RUN <<_INSTALL_FLATPAK
+RUN <<_INSTALL_KODI
 
 set -e
 apt-get update
@@ -26,13 +26,6 @@ rm -rf \
     /var/tmp/* \
     /tmp/*
 
-_INSTALL_FLATPAK
-
-#
-# System wide install of Kodi
-RUN <<_INSTALL_KODI
-
-set -e
 # Fix bwarp perms for flatpaks
 chmod u+s /usr/bin/bwrap
 service dbus start

--- a/images/kodi/Dockerfile
+++ b/images/kodi/Dockerfile
@@ -5,6 +5,7 @@ ARG BASE_APP_IMAGE
 FROM ${BASE_APP_IMAGE}
 
 ARG CORE_PACKAGES=" \
+    dbus \
     flatpak \
     "
 
@@ -30,6 +31,8 @@ RUN \
 # 
 # Fix bwarp perms for flatpaks
 RUN chmod u+s /usr/bin/bwrap
+
+COPY overlay /
 
 # 
 # Replace launch scripts

--- a/images/kodi/Dockerfile
+++ b/images/kodi/Dockerfile
@@ -11,6 +11,7 @@ ARG CORE_PACKAGES=" \
 
 RUN <<_INSTALL_FLATPAK
 
+set -e
 apt-get update
 # Install core packages
 apt-get install -y --no-install-recommends $CORE_PACKAGES
@@ -27,14 +28,13 @@ rm -rf \
 
 _INSTALL_FLATPAK
 
-# 
-# Fix bwarp perms for flatpaks
-RUN chmod u+s /usr/bin/bwrap
-
 #
 # System wide install of Kodi
 RUN <<_INSTALL_KODI
 
+set -e
+# Fix bwarp perms for flatpaks
+chmod u+s /usr/bin/bwrap
 service dbus start
 flatpak remote-add --system --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 flatpak install -y --noninteractive --system tv.kodi.Kodi

--- a/images/kodi/overlay/etc/cont-init.d/99-startdbus.sh
+++ b/images/kodi/overlay/etc/cont-init.d/99-startdbus.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+service dbus start

--- a/images/kodi/scripts/startup-10-create-dirs.sh
+++ b/images/kodi/scripts/startup-10-create-dirs.sh
@@ -3,14 +3,14 @@
 gow_log "[start-create-dirs] Begin"
 
 # configure the controller.
-if [ ! -d "${HOME}/.kodi/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux" ]
+if [ ! -d "${HOME}/.var/app/tv.kodi.Kodi/data/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux" ]
 then
     gow_log "[start-create-dirs] Creating controller config file."
-    mkdir -p "${HOME}/.kodi/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/"
-    cp "/opt/gow/Xbox_controller.xml" "${HOME}/.kodi/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/Wolf_X-Box_One__virtual__pad_11b_8a.xml"
-    cp "/opt/gow/Switch_controller.xml" "${HOME}/.kodi/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/Wolf_Nintendo__virtual__pad_14b_6a.xml"
-    cp "/opt/gow/PS_controller.xml" "${HOME}/.kodi/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/Wolf_DualSense__virtual__pad_13b_8a.xml"
-    cp "/opt/gow/settings.xml" "${HOME}/.kodi/userdata/addon_data/peripheral.joystick/settings.xml"
+    mkdir -p "${HOME}/.var/app/tv.kodi.Kodi/data/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/"
+    cp "/opt/gow/Xbox_controller.xml" "${HOME}/.var/app/tv.kodi.Kodi/data/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/Wolf_X-Box_One__virtual__pad_11b_8a.xml"
+    cp "/opt/gow/Switch_controller.xml" "${HOME}/.var/app/tv.kodi.Kodi/data/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/Wolf_Nintendo__virtual__pad_14b_6a.xml"
+    cp "/opt/gow/PS_controller.xml" "${HOME}/.var/app/tv.kodi.Kodi/data/userdata/addon_data/peripheral.joystick/resources/buttonmaps/xml/linux/Wolf_DualSense__virtual__pad_13b_8a.xml"
+    cp "/opt/gow/settings.xml" "${HOME}/.var/app/tv.kodi.Kodi/data/userdata/addon_data/peripheral.joystick/settings.xml"
 fi
 
 gow_log "[start-create-dirs] End"

--- a/images/kodi/scripts/startup.sh
+++ b/images/kodi/scripts/startup.sh
@@ -11,10 +11,16 @@ for file in /opt/gow/startup.d/* ; do
     fi
 done
 
-gow_log "Installing Kodi"
 
-flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-flatpak install -y --noninteractive tv.kodi.Kodi
+
+export XDG_DATA_DIRS=/var/lib/flatpak/exports/share:/home/retro/.local/share/flatpak/exports/share:/usr/local/share/:/usr/share/
+
+# user wide install of kodi
+#gow_log "Installing Kodi"
+#flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+#flatpak install -y --noninteractive tv.kodi.Kodi
+#flatpak override --user tv.kodi.Kodi --filesystem=home
+#flatpak update -y --noninteractive
 
 gow_log "Starting Kodi"
 source /opt/gow/launch-comp.sh

--- a/images/kodi/scripts/startup.sh
+++ b/images/kodi/scripts/startup.sh
@@ -15,4 +15,3 @@ gow_log "Starting Kodi"
 
 source /opt/gow/launch-comp.sh
 launcher kodi
-#launcher jstest-gtk

--- a/images/kodi/scripts/startup.sh
+++ b/images/kodi/scripts/startup.sh
@@ -11,10 +11,11 @@ for file in /opt/gow/startup.d/* ; do
     fi
 done
 
-gow_log "Starting Kodi"
+gow_log "Installing Kodi"
 
 flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-flatpak install -y tv.kodi.Kodi
+flatpak install -y --noninteractive tv.kodi.Kodi
 
+gow_log "Starting Kodi"
 source /opt/gow/launch-comp.sh
 launcher flatpak run tv.kodi.Kodi

--- a/images/kodi/scripts/startup.sh
+++ b/images/kodi/scripts/startup.sh
@@ -13,5 +13,8 @@ done
 
 gow_log "Starting Kodi"
 
+flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install -y tv.kodi.Kodi
+
 source /opt/gow/launch-comp.sh
-launcher kodi
+launcher flatpak run tv.kodi.Kodi


### PR DESCRIPTION
A complete redo of the Kodi image via system wide Flatpak install.
This PR makes #212 obsolete.

This image contains all Addons that come bundled with the Flatpak version of Kodi.
Some Addons may be disabled at first start, and can be enabled later.

Testing and feedback is always welcome ;-)