### PR TITLE
The filename of heroic release file don't have underscore anymore

### DIFF
--- a/apps/heroic-games-launcher/build/Dockerfile
+++ b/apps/heroic-games-launcher/build/Dockerfile
@@ -49,7 +49,7 @@ RUN <<_INSTALL_HEROIC
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-github_download "Heroic-Games-Launcher/HeroicGamesLauncher" ".assets[]|select(.name|endswith(\"_amd64.deb\")).browser_download_url" "heroic.deb"
+github_download "Heroic-Games-Launcher/HeroicGamesLauncher" ".assets[]|select(.name|endswith(\"amd64.deb\")).browser_download_url" "heroic.deb"
 dpkg -i heroic.deb
 rm heroic.deb
 _INSTALL_HEROIC


### PR DESCRIPTION
They changed the release filename

Before:
heroic_2.15.2_amd64.deb

Now:
Heroic-2.16.0-linux-amd64.deb