### PR TITLE
Adds MangoHud to Lutris and associated config file, and updated Lutris from git

### DIFF
--- a/apps/lutris/build/Dockerfile
+++ b/apps/lutris/build/Dockerfile
@@ -5,6 +5,10 @@ FROM ${BASE_APP_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+#GitHub REST query versioning
+ARG GITHUB_REST_VERSION=2022-11-28
+
+
 # The following list of packages is informed by these articles;
 #   - https://github.com/lutris/docs/blob/master/InstallingDrivers.md
 #   - https://github.com/lutris/docs/blob/master/WineDependencies.md
@@ -24,7 +28,6 @@ ARG REQUIRED_PACKAGES=" \
     wine-stable \
     winetricks \
     zenity \
-    mangohud \
     "
 
 RUN dpkg --add-architecture i386 && \
@@ -34,11 +37,35 @@ RUN dpkg --add-architecture i386 && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
+
+RUN  <<_UPDATE_LUTRIS
+  #!/bin/bash
+  set -e
+
+
+ github_download(){
+    curl -H "X-GitHub-Api-Version: "$(GITHUB_REST_VERSION)"" \
+        https://api.github.com/repos/$1/releases/latest | \
+        jq ".assets[]|select(.name|endswith(\"${3}\")).browser_download_url" | \
+        xargs wget -O $2
+ }
+
+ echo "**** Downloading latest Lutris deb ****"
+ github_download "lutris/lutris" "lutris.deb" "all.deb"
+
+ apt-get install -y ./lutris.deb
+
+ # Cleanup
+  rm lutris.deb
+_UPDATE_LUTRIS
+
+
 RUN mkdir -pm 777 /var/lutris/ && \
     mkdir /opt/gow/startup.d/
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/startup-10-create-dirs.sh /opt/gow/startup.d/10-create-dirs.sh
-COPY configs /opt/gow
+COPY configs/lutris-system.yml /opt/gow/lutris-system.yml
+COPY configs/lutris-lutris.conf /opt/gow/lutris-lutris.conf
 
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
 

--- a/apps/lutris/build/Dockerfile
+++ b/apps/lutris/build/Dockerfile
@@ -28,6 +28,7 @@ ARG REQUIRED_PACKAGES=" \
     wine-stable \
     winetricks \
     zenity \
+    mangohud \
     "
 
 RUN dpkg --add-architecture i386 && \

--- a/apps/lutris/build/Dockerfile
+++ b/apps/lutris/build/Dockerfile
@@ -24,6 +24,7 @@ ARG REQUIRED_PACKAGES=" \
     wine-stable \
     winetricks \
     zenity \
+    mangohud \
     "
 
 RUN dpkg --add-architecture i386 && \
@@ -37,8 +38,7 @@ RUN mkdir -pm 777 /var/lutris/ && \
     mkdir /opt/gow/startup.d/
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/startup-10-create-dirs.sh /opt/gow/startup.d/10-create-dirs.sh
-COPY configs/lutris-system.yml /opt/gow/lutris-system.yml
-COPY configs/lutris-lutris.conf /opt/gow/lutris-lutris.conf
+COPY configs /opt/gow
 
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix
 

--- a/apps/lutris/build/configs/MangoHud/MangoHud.conf
+++ b/apps/lutris/build/configs/MangoHud/MangoHud.conf
@@ -1,0 +1,7 @@
+fps_limit=120
+vsync=1
+gl_vsync=0
+show_fps_limit=1
+hud_compact
+present_mode
+no_display

--- a/apps/lutris/build/scripts/startup-10-create-dirs.sh
+++ b/apps/lutris/build/scripts/startup-10-create-dirs.sh
@@ -55,4 +55,13 @@ then
     cp "/opt/gow/lutris-lutris.conf" "${HOME}/.config/lutris/lutris.conf"
 fi
 
+# copy default MagoHud config.
+if [ ! -f "${HOME}/.config/MangoHud/MangoHud.conf" ]
+then
+    gow_log "[start-create-dirs] Creating MangoHud config file."
+    mkdir -p "${HOME}/.config/MangoHud"
+    cp "/opt/gow/MangoHud/MangoHud.conf" "${HOME}/.config/MangoHud/MangoHud.conf"
+fi
+
+
 gow_log "[start-create-dirs] End"


### PR DESCRIPTION
MangoHud is able to be toggled by a switch in Lutris settings, default config file disables vsync, since the only thing it does in our case - adds latency. Also sets a 120fps cap, which sounds reasonable for current architecture.