### PR TITLE
fix: native linux games with the wrong audio output

### DIFF
--- a/images/pulseaudio/build/configs/default.pa
+++ b/images/pulseaudio/build/configs/default.pa
@@ -18,7 +18,7 @@
 #.endif
 
 # Adds a default null sink
-load-module module-null-sink
+#load-module module-null-sink
 
 ### Make sure we always have a sink around, even if it is a null sink.
 load-module module-always-sink


### PR DESCRIPTION
I don’t know if this PR is right so I need some help, fill free to correct me.

I will try to explain the best way I can.

I had a problem that my audio didn’t work with native linux games, but with wine worked. 
I tried with two native games, Minecraft and Valheim, the problem was that these games were choosing the wrong audio output, because inside of Minecraft audio config I had to change the output to "null output #2" for it to work, sadly Valheim don't have this option in the game.

I don’t know much about Pulseaudio so I tried to search a bit about this, and I tried messing with the config files, and when I tested commenting the line of "load-module module-null-sink" all the games worked e I don't even know why 😂

After changing this I tested the audio of Firefox, Steam and Heroic Games, and all of them work. But I don't know if this breaks something.