### PR TITLE
Updated Pegasus to be able to use zip files for ScuumVM and iso files for PS3

### DIFF
--- a/apps/pegasus/_index.md
+++ b/apps/pegasus/_index.md
@@ -46,6 +46,7 @@ can either create the ROM directories in the format below or edit Pegasus to use
 /ROMs/psp
 /ROMs/psx
 /ROMs/saturn
+/ROMs/scummvm
 /ROMs/sega32x
 /ROMs/segacd
 /ROMs/snes
@@ -72,6 +73,53 @@ mounts = [
     "/mnt/PATH_TO_ROMS_IN_YOUR_HOST/:/ROMs/:rw" # <-- EDIT HERE
 ]
 ```
+## Special Notes
+
+### Setting up the `pegasus.metadata.txt` file
+
+There is a `rom_launcher.sh` script to make life easier. When using it, as long as you use the same folder name
+used for the ROM it'll be able to find it. For example, for PS3:
+
+```text
+collection: Sony Playstation 3
+shortname: ps3
+command: /Applications/launchers/rom_launcher.sh ps3 "{file.path}"
+
+...
+```
+
+### PS3 games
+
+ISOs are supported! Just use the above `rom_launcher.sh` script.
+
+### ScummVM
+
+ScummVM will work with zip files if you use the `rom_launcher.sh` script!
+
+You must first prepare the zip file for this to work correctly:
+- Add the complete game in the root of the zip file
+- Add a `*.scummvm` file inside of the root of the zip file.
+  - This file must contain the official "name" that ScummVM associates with this game
+  - This name can be found in the following [yaml file](https://github.com/scummvm/scummvm-web/blob/master/data/en/games.yaml)
+    - It is the `id` portion that comes after the `:`.
+      - For example:
+          ```yaml
+            -
+              id: 'scumm:tentacle'
+              name: 'Maniac Mansion: Day of the Tentacle'
+              engine_id: scumm
+              company_id: lucasarts
+              year: '1993'
+              moby_id: '719'
+              steam_id: ''
+              gog_id: ''
+              zoom_id: ''
+              additional_stores: ''
+              datafiles: Day_of_the_Tentacle
+              wikipedia_page: Day_of_the_Tentacle
+              series_id: maniac
+          ```
+        `tentacle` would be what you would put on the first line of the `*.scummvm` file 
 
 ## Customization
 

--- a/apps/pegasus/build/Dockerfile
+++ b/apps/pegasus/build/Dockerfile
@@ -18,6 +18,21 @@ RUN \
 		apt-get autoremove -y && \
 		rm -rf /var/lib/apt/lists/*
 
+# Install software to mount iso/zip
+RUN \
+    echo "**** Install mount iso & zip dependencies ****" && \
+        apt-get update && \
+        apt-get install -y \
+            fuseiso \
+            fuse-zip \
+            && \
+    # Cleanup \
+		apt-get autoremove -y && \
+		rm -rf /var/lib/apt/lists/*
+
+# Setup ISO mounting location
+RUN mkdir -p /media/iso_mount && chown 1000:1000 /media/iso_mount
+
 # Install pegasus
 RUN  <<_INSTALL_PEGASUS
   #!/bin/bash

--- a/apps/pegasus/build/configs/app/game_dirs.txt
+++ b/apps/pegasus/build/configs/app/game_dirs.txt
@@ -31,6 +31,7 @@
 /ROMs/psp
 /ROMs/psx
 /ROMs/saturn
+/ROMs/scummvm
 /ROMs/sega32x
 /ROMs/segacd
 /ROMs/snes

--- a/apps/pegasus/build/configs/app/metadata.pegasus.txt
+++ b/apps/pegasus/build/configs/app/metadata.pegasus.txt
@@ -9,6 +9,11 @@ files:
   /Applications/launchers/xemu.sh
   /Applications/launchers/rpcs3.sh
   /bin/Install_RPCS3_Firmware.sh
+  /usr/bin/kitty
+
+game: Bash Console
+file: /usr/bin/kitty
+description: Bash Console
 
 game: Emulators - Cemu
 release: 2015-10-13

--- a/images/base-emu/build/launchers/rom_launcher.sh
+++ b/images/base-emu/build/launchers/rom_launcher.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+EMULATOR=$1
+ROM=$2
+
+# Mount location where we will mount both zip files and iso files
+ISO_MOUNT_LOCATION=/media/iso_mount
+
+function launch_ps3 {
+
+  local ROM_FILE="$1"
+
+  # Mount the folder/file if it's an iso
+  if [[ $ROM_FILE == *.iso ]]; then
+    echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
+    fuseiso "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
+    ROM_FILE=${ISO_MOUNT_LOCATION}
+  fi
+
+  # Launch the game
+  /Applications/rpcs3-emu.AppImage --appimage-extract-and-run  "${ROM_FILE}"
+
+  # Unmount (if we mounted the ISO)
+  if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
+    echo "UnMounting: ${ISO_MOUNT_LOCATION}"
+    fusermount -u ${ISO_MOUNT_LOCATION}
+  fi
+}
+
+function launch_scummvm {
+
+  local ROM_FILE="$1"
+
+  # Mount the folder/file if it's an iso
+  if [[ $ROM_FILE == *.zip ]]; then
+    echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
+    fuse-zip -o ro "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
+    ROM_FILE=${ISO_MOUNT_LOCATION}
+  fi
+
+  # Find the .scummvm filename
+  SCUMMVM_FILE=`ls ${ISO_MOUNT_LOCATION}/*.scummvm`
+
+  # Launch the game
+  retroarch -L ~/.config/retroarch/cores/scummvm_libretro.so ${ISO_MOUNT_LOCATION}/${SCUMMVM_FILE}
+
+  # Unmount (if we mounted the ISO)
+  if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
+    echo "UnMounting: ${ISO_MOUNT_LOCATION}"
+    fusermount -u ${ISO_MOUNT_LOCATION}
+  fi
+}
+
+# dictionary of emulator to command to run
+declare -A EMULATOR_COMMAND=( \
+["3do"]="retroarch --fullscreen -L ~/.config/retroarch/cores/opera_libretro.so \"${ROM}\"" \
+["arcade"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mame_libretro.so \"${ROM}\"" \
+["amiga"]="retroarch --fullscreen -L ~/.config/retroarch/cores/puae_libretro.so \"${ROM}\"" \
+["amigacd32"]="retroarch --fullscreen -L ~/.config/retroarch/cores/puae_libretro.so \"${ROM}\"" \
+["atari2600"]="retroarch --fullscreen -L ~/.config/retroarch/cores/stella_libretro.so \"${ROM}\"" \
+["atari5200"]="retroarch --fullscreen -L ~/.config/retroarch/cores/a5200_libretro.so \"${ROM}\"" \
+["atari7800"]="retroarch --fullscreen -L ~/.config/retroarch/cores/prosystem_libretro.so \"${ROM}\"" \
+["atarijaguar"]="retroarch --fullscreen -L ~/.config/retroarch/cores/virtualjaguar_libretro.so \"${ROM}\"" \
+["atarijaguarcd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/virtualjaguar_libretro.so \"${ROM}\"" \
+["atarilynx"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_lynx_libretro.so \"${ROM}\"" \
+["dreamcast"]="retroarch --fullscreen -L ~/.config/retroarch/cores/flycast_libretro.so \"${ROM}\"" \
+["gb"]="retroarch --fullscreen -L ~/.config/retroarch/cores/gambatte_libretro.so \"${ROM}\"" \
+["gbc"]="retroarch --fullscreen -L ~/.config/retroarch/cores/gambatte_libretro.so \"${ROM}\"" \
+["gba"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mgba_libretro.so \"${ROM}\"" \
+["gc"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
+["genesis"]="retroarch --fullscreen -L ~/.config/retroarch/cores/picodrive_libretro.so \"${ROM}\"" \
+["megacd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
+["model2"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mame_libretro.so \"${ROM}\"" \
+["n64"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mupen64plus_next_libretro.so \"${ROM}\"" \
+["naomi"]="retroarch --fullscreen -L ~/.config/retroarch/cores/flycast_libretro.so \"${ROM}\"" \
+["neogeo"]="retroarch --fullscreen -L ~/.config/retroarch/cores/fbneo_libretro.so \"${ROM}\"" \
+["nes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/fceumm_libretro.so \"${ROM}\"" \
+["ngp"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_ngp_libretro.so \"${ROM}\"" \
+["ngpc"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_ngp_libretro.so \"${ROM}\"" \
+["psp"]="retroarch --fullscreen -L ~/.config/retroarch/cores/ppsspp_libretro.so \"${ROM}\"" \
+["psx"]="retroarch --fullscreen -L ~/.config/retroarch/cores/pcsx_rearmed_libretro.so \"${ROM}\"" \
+["ps2"]="/Applications/pcsx2-emu.AppImage --appimage-extract-and-run \"${ROM}\"" \
+["ps3"]="launch_ps3  \"${ROM}\"" \
+["saturn"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_saturn_libretro.so \"${ROM}\"" \
+["sega32x"]="retroarch --fullscreen -L ~/.config/retroarch/cores/picodrive_libretro.so \"${ROM}\"" \
+["segacd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
+["scummvm"]="launch_scummvm \"${ROM}\"" \
+["snes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/snes9x_libretro.so \"${ROM}\"" \
+["snes_widescreen"]="retroarch --fullscreen -L ~/.config/retroarch/cores/bsnes_hd_beta_libretro.so \"${ROM}\"" \
+["virtualboy"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_vb_libretro.so \"${ROM}\"" \
+["wii"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
+["wiiu"]="/Applications/cemu-emu.AppImage --appimage-extract-and-run -f -g \"${ROM}\"" \
+["wonderswan"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_wswan_libretro.so \"${ROM}\"" \
+["wonderswancolor"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_wswan_libretro.so \"${ROM}\"" \
+["xbox"]="/Applications/xemu-emu.AppImage --appimage-extract-and-run -full-screen -dvd_path \"${ROM}\"" \
+)
+
+echo "Running command: ${EMULATOR_COMMAND[${EMULATOR}]}"
+eval ${EMULATOR_COMMAND[${EMULATOR}]}


### PR DESCRIPTION

- Added the "rom_launcher" back into the system as the mounting logic is in this script. It is in the "base-emu" image.
- Updated the documentation to explain how to use it.
- Updated the game_dirs.txt to include the new scummvm reference
- Updated the default metadata.pegasus.txt to be able to launch "kitty". Very useful for people that need to run some commands on the command line if desired. Also aids in troubleshooting.