### PR TITLE
Feature: Mesa-25 from oibaf:ppa

### DIFF
--- a/images/base/build/Dockerfile
+++ b/images/base/build/Dockerfile
@@ -23,6 +23,11 @@ set -e
 echo "**** Update apt database ****"
 apt-get update
 
+echo "**** Add Mesa repo from oibaf ****"
+apt-get install -y --no-install-recommends \
+    software-properties-common
+add-apt-repository ppa:oibaf/graphics-drivers
+
 echo "**** Install certificates ****"
 apt-get install -y --reinstall --no-install-recommends \
     ca-certificates


### PR DESCRIPTION
Mesa-25 is required for newer graphics cards, such as AMD's Radeon RX 9070.

This adds [oibaf:ppa](https://launchpad.net/~oibaf/+archive/ubuntu/graphics-drivers) repository to the base image. Subsequent images will then pull the newer version of mesa.

Tested on my local machine building docker images for: base, base-app, base-emu, steam, and a custom pegasus.