### PR TITLE
feat: added mangohud to required packages

### DIFF
--- a/.github/workflows/mirror-repo.yml
+++ b/.github/workflows/mirror-repo.yml
@@ -3,6 +3,8 @@ name: Repo Mirror
 on: [ push ]
 jobs:
   codeberg:
+    # This job will only run if the repository is 'games-on-whales/gow'
+    if: github.repository == 'games-on-whales/gow'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/apps/heroic-games-launcher/build/Dockerfile
+++ b/apps/heroic-games-launcher/build/Dockerfile
@@ -54,19 +54,6 @@ dpkg -i heroic.deb
 rm heroic.deb
 _INSTALL_HEROIC
 
-RUN <<_INSTALL_MANGO
-#!/bin/bash
-set -e
-source /opt/gow/bash-lib/utils.sh
-
-github_download "flightlessmango/MangoHud" ".assets[]|select(.name|endswith(\".tar.gz\")).browser_download_url" "MangoHud.tar.gz"
-tar xf MangoHud.tar.gz
-cd MangoHud
-tar xf MangoHud-package.tar
-chmod +x ./mangohud-setup.sh && ./mangohud-setup.sh install
-rm -rf /MangoHud
-_INSTALL_MANGO
-
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix

--- a/apps/steam/build/Dockerfile
+++ b/apps/steam/build/Dockerfile
@@ -29,7 +29,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG REQUIRED_PACKAGES=" \
     steam \
     dbus-daemon dbus-system-bus-common dbus-session-bus-common whoopsie network-manager bluez \
-    mangoapp ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils pciutils lsb-release mesa-utils \
+    ibus curl pkexec xz-utils zenity file xdg-user-dirs xdg-utils pciutils lsb-release mesa-utils \
     libfontconfig1:i386 libfontconfig1:amd64 libfreetype6 libfreetype6:i386 \
 "
 

--- a/images/base-app/build/Dockerfile
+++ b/images/base-app/build/Dockerfile
@@ -87,7 +87,7 @@ RUN <<_INSTALL_GAMESCOPE
 
     # Dependencies
     DEV_PACKAGES="\
-        git curl build-essential gcc pkg-config ninja-build meson cmake equivs libcap2-bin \
+        git build-essential gcc pkg-config ninja-build meson cmake equivs libcap2-bin \
         libvulkan-dev libwayland-dev wayland-protocols libudev-dev libinput-dev libpixman-1-dev libseat-dev libssl-dev libcap-dev \
         libx11-dev libx11-xcb-dev libxdamage-dev libxxf86vm-dev libxres-dev libxmu-dev libx11-xcb-dev libxcomposite-dev libxtst-dev \
         libxrender-dev libxshmfence-dev libxkbfile-dev libxkbcommon-dev libxfont-dev libxcvt-dev libgl-dev \

--- a/images/base-app/build/Dockerfile
+++ b/images/base-app/build/Dockerfile
@@ -152,5 +152,21 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=sdl-jstest-builder /sdl-jstest/build/sdl2-jstest /usr/local/bin/sdl2-jstest
 
+#################################
+# Install MangoHuD
+#################################
+RUN <<_INSTALL_MANGO
+#!/bin/bash
+set -e
+source /opt/gow/bash-lib/utils.sh
+
+github_download "flightlessmango/MangoHud" ".assets[]|select(.name|endswith(\".tar.gz\")).browser_download_url" "MangoHud.tar.gz"
+tar xf MangoHud.tar.gz
+cd MangoHud
+tar xf MangoHud-package.tar
+chmod +x ./mangohud-setup.sh && ./mangohud-setup.sh install
+rm -rf /MangoHud
+_INSTALL_MANGO
+
 # Configure the default directory to be the 'retro' users home directory
 WORKDIR ${HOME}

--- a/images/base/build/Dockerfile
+++ b/images/base/build/Dockerfile
@@ -37,6 +37,7 @@ apt-get install -y --no-install-recommends \
     fuse \
     libnss3 \
     wget \
+    curl \
     jq
 
 echo "**** Install gosu ****"

--- a/images/base/build/overlay/opt/gow/bash-lib/utils.sh
+++ b/images/base/build/overlay/opt/gow/bash-lib/utils.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -u
 
 gow_log() {
     echo "$(date +"[%Y-%m-%d %H:%M:%S]") $*"
@@ -7,7 +9,7 @@ gow_log() {
 join_by() { local IFS="$1"; shift; echo "$*"; }
 
 github_download(){
-    curl -H "X-GitHub-Api-Version: "$(GITHUB_REST_VERSION:-2022-11-28)"" \
+    curl -H "X-GitHub-Api-Version: "${GITHUB_REST_VERSION:-2022-11-28}"" \
         https://api.github.com/repos/$1/releases/latest | \
         jq $2 | \
         xargs wget -O $3


### PR DESCRIPTION
Since PrismLauncher brings support for Mangohud and it's definitely better than Minecrafts F3 debug overlay, we should include it in the image.