### PR TITLE
feat(steam): allow proper exit through power menu

### DIFF
--- a/apps/steam/build/Dockerfile
+++ b/apps/steam/build/Dockerfile
@@ -69,6 +69,7 @@ COPY --chmod=777 steamos-update /usr/bin/steamos-polkit-helpers/steamos-update
 COPY --chmod=777 steamos-session-select /usr/bin/steamos-session-select
 COPY --chmod=777 jupiter-biosupdate /usr/bin/jupiter-biosupdate
 COPY --chmod=777 jupiter-biosupdate /usr/bin/steamos-polkit-helpers/jupiter-biosupdate
+COPY --chmod=777 scripts/steamos-dbus-watchdog.sh /usr/local/bin/steamos-dbus-watchdog.sh
 COPY --from=bwrap-builder --chmod=755 /root/bubblewrap/_builddir/bwrap /usr/bin/bwrap
 
 ENV XDG_RUNTIME_DIR=/tmp/.X11-unix

--- a/apps/steam/build/scripts/steamos-dbus-watchdog.sh
+++ b/apps/steam/build/scripts/steamos-dbus-watchdog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+source /opt/gow/bash-lib/utils.sh
+
+function shutdown_steam() {
+    gow_log "[steamos-dbus-watchdog] Shutting down Steam..."
+    /usr/games/steam -shutdown
+    exit 0
+}
+
+gow_log "[steamos-dbus-watchdog] Starting D-Bus watcher for Steam shutdown..."
+dbus-monitor --system "interface='org.freedesktop.login1.Manager'" | \
+while read -r line; do
+    if echo "$line" | grep -q "member=PowerOff"; then
+        gow_log "[steamos-dbus-watchdog] Detected 'PowerOff' D-Bus call!"
+        shutdown_steam
+    fi
+
+    if echo "$line" | grep -q "member=Reboot"; then
+        gow_log "[steamos-dbus-watchdog] Detected 'Reboot' D-Bus call!"
+        shutdown_steam
+    fi
+
+    if echo "$line" | grep -q "member=Suspend"; then
+        gow_log "[steamos-dbus-watchdog] Detected 'Suspend' D-Bus call!"
+        shutdown_steam
+    fi
+done

--- a/apps/steam/build/scripts/system-services.sh
+++ b/apps/steam/build/scripts/system-services.sh
@@ -8,5 +8,8 @@ bluetoothd --nodetach &
 echo "*** Bluez started ***"
 NetworkManager
 echo "*** NetworkManager started ***"
+# Watchdog will stop steam when selecting Turn off, Suspend or Restart from the Steam power menu
+steamos-dbus-watchdog.sh &
+echo "*** D-Bus Watchdog started ***"
 
 disown


### PR DESCRIPTION
steamos-dbus-watchdog.sh listens for dbus messages which are sent by Steam Big Picture's power menu and then sends a shutdown signal to steam using the -shutdown arg. This allows stopping using the power menu which is useful when using steam with -steamos/-steamdeck args.

We could also integrate something similar like to this script into the base-app image that SIGTERMs gamescope and sway when we detect a Shutdown signal on the DBus, this would add compatibility for other launchers that have a power menu, like Kodi for example and other frontends. At least if these frontends actually are using the D-Bus to communicate, which would require some testing.