### PR TITLE
Fix the pegasus dockfile

### DIFF
--- a/apps/pegasus/build/Dockerfile
+++ b/apps/pegasus/build/Dockerfile
@@ -7,43 +7,26 @@ ARG DEBIAN_FRONTEND=noninteractive
 # see: https://github.com/AppImage/AppImageKit/wiki/FUSE#docker
 ENV APPIMAGE_EXTRACT_AND_RUN=1
 
-# Install prereqs
+ARG REQUIRED_PACKAGES=" \
+    libgstreamer-gl1.0-0 \
+    fuseiso \
+    fuse-zip \
+    "
+
+# Install packages
 RUN \
     echo "**** Install Prereqs ****" && \
         apt-get update && \
-        apt-get install -y \
-            libgstreamer-gl1.0-0 \
-            && \
+        apt-get install -y  $REQUIRED_PACKAGES && \
 	# Cleanup \
-		apt-get autoremove -y && \
-		rm -rf /var/lib/apt/lists/*
-
-# Install software to mount iso/zip
-RUN \
-    echo "**** Install mount iso & zip dependencies ****" && \
-        apt-get update && \
-        apt-get install -y \
-            fuseiso \
-            fuse-zip \
-            && \
-    # Cleanup \
 		apt-get autoremove -y && \
 		rm -rf /var/lib/apt/lists/*
 
 # Setup ISO mounting location
 RUN mkdir -p /media/iso_mount && chown 1000:1000 /media/iso_mount
 
-# Install pegasus
-RUN  <<_INSTALL_PEGASUS
-#!/bin/bash
-set -e
-
-echo "**** Installing pegasus ****"
-apt-get update -y
-
 # Create a dummy policykit-1 package to satisfy the dependency
-mkdir -p /tmp/policykit-dummy/DEBIAN
-cat > /tmp/policykit-dummy/DEBIAN/control << 'EOF'
+COPY <<_APT_POLICYKIT /tmp/policykit-dummy/DEBIAN/control
 Package: policykit-1
 Version: 999.0
 Architecture: amd64
@@ -53,10 +36,18 @@ Depends: polkitd, pkexec
 Provides: policykit-1
 Replaces: policykit-1
 Conflicts: policykit-1
-EOF
+_APT_POLICYKIT
+
+# Install pegasus
+RUN  <<_INSTALL_PEGASUS
+#!/bin/bash
+set -e
+
+echo "**** Installing pegasus ****"
+apt-get update -y
 
 dpkg-deb --build /tmp/policykit-dummy /tmp/policykit-1_999.0_amd64.deb
-dpkg -i /tmp/policykit-1_999.0_amd64.deb
+apt-get install -y /tmp/policykit-1_999.0_amd64.deb
 
 # Pegasus still requires libssl1.1, but ubuntu switched to libssl3. Need to manually install it.
 # TODO: Doing this could be a terrible idea (it does work)

--- a/apps/pegasus/build/Dockerfile
+++ b/apps/pegasus/build/Dockerfile
@@ -35,45 +35,45 @@ RUN mkdir -p /media/iso_mount && chown 1000:1000 /media/iso_mount
 
 # Install pegasus
 RUN  <<_INSTALL_PEGASUS
-  #!/bin/bash
-  set -e
+#!/bin/bash
+set -e
 
-  echo "**** Installing pegasus ****"
-  apt-get update -y
+echo "**** Installing pegasus ****"
+apt-get update -y
 
-  # Create a dummy policykit-1 package to satisfy the dependency
-  mkdir -p /tmp/policykit-dummy/DEBIAN
-  cat > /tmp/policykit-dummy/DEBIAN/control << 'EOF'
-  Package: policykit-1
-  Version: 999.0
-  Architecture: amd64
-  Maintainer: Dummy Package
-  Description: Transitional dummy package for policykit-1
-  Depends: polkitd, pkexec
-  Provides: policykit-1
-  Replaces: policykit-1
-  Conflicts: policykit-1
-  EOF
+# Create a dummy policykit-1 package to satisfy the dependency
+mkdir -p /tmp/policykit-dummy/DEBIAN
+cat > /tmp/policykit-dummy/DEBIAN/control << 'EOF'
+Package: policykit-1
+Version: 999.0
+Architecture: amd64
+Maintainer: Dummy Package
+Description: Transitional dummy package for policykit-1
+Depends: polkitd, pkexec
+Provides: policykit-1
+Replaces: policykit-1
+Conflicts: policykit-1
+EOF
 
-  dpkg-deb --build /tmp/policykit-dummy /tmp/policykit-1_999.0_amd64.deb
-  dpkg -i /tmp/policykit-1_999.0_amd64.deb
+dpkg-deb --build /tmp/policykit-dummy /tmp/policykit-1_999.0_amd64.deb
+dpkg -i /tmp/policykit-1_999.0_amd64.deb
 
-  # Pegasus still requires libssl1.1, but ubuntu switched to libssl3. Need to manually install it.
-  # TODO: Doing this could be a terrible idea (it does work)
-  wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb --output-document=libssl1.1.deb
-  apt-get install -y ./libssl1.1.deb
+# Pegasus still requires libssl1.1, but ubuntu switched to libssl3. Need to manually install it.
+# TODO: Doing this could be a terrible idea (it does work)
+wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb --output-document=libssl1.1.deb
+apt-get install -y ./libssl1.1.deb
 
-  # Pegasus doesn't tag releases, they have a rolling weekly release
-  # so we have to parse the Github APIs to get the link
-  curl -s https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous | \
-  jq -r '.assets[] | select(.name | contains(".deb")) | .browser_download_url' | \
-  xargs curl -fsSL -o pegasus.deb
+# Pegasus doesn't tag releases, they have a rolling weekly release
+# so we have to parse the Github APIs to get the link
+curl -s https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous | \
+jq -r '.assets[] | select(.name | contains(".deb")) | .browser_download_url' | \
+xargs curl -fsSL -o pegasus.deb
 
-  apt-get install -y ./pegasus.deb
+apt-get install -y ./pegasus.deb
 
-  # Cleanup
-  rm pegasus.deb libssl1.1.deb
-  rm -rf /var/lib/apt/lists/*
+# Cleanup
+rm pegasus.deb libssl1.1.deb
+rm -rf /var/lib/apt/lists/*
 _INSTALL_PEGASUS
 
 # Copy config files


### PR DESCRIPTION
cat command did not like the indentation in the dockerfile:
1. indentation spaces are written in the tmp file
2. EOF gets ignored
This caused the install command of pegasus to be skipped.

I have removed the indentation in the pegasus install section. This is tested to fix the problem on my PC.