### PR TITLE
Ensure GHCR_NAMESPACE is all lowercase.

### DIFF
--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -68,6 +68,7 @@ jobs:
               GHCR_NAMESPACE="${owner}/gow"
             else
               # For branches, we use the repository owner as namespace
+              owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
               GHCR_NAMESPACE="${{ github.repository_owner }}/gow"
             fi
             DOCKERHUB_NAMESPACE="${{ env.DOCKERHUB_NAMESPACE }}"

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -69,7 +69,7 @@ jobs:
             else
               # For branches, we use the repository owner as namespace
               owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-              GHCR_NAMESPACE="${{ github.repository_owner }}/gow"
+              GHCR_NAMESPACE="${owner}/gow"
             fi
             DOCKERHUB_NAMESPACE="${{ env.DOCKERHUB_NAMESPACE }}"
             ARM64_RUNNER=${{ env.ARM64_RUNNER != '' && env.ARM64_RUNNER || 'ubuntu-latest' }}

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -64,7 +64,8 @@ jobs:
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               # For PRs, we use the forked repository owner as namespace
               # This allows us to pull build caches from the forked repository
-              GHCR_NAMESPACE="${{ github.event.pull_request.head.repo.owner.login }}/gow"
+              owner=$(echo ${{ github.event.pull_request.head.repo.owner.login }} | tr '[:upper:]' '[:lower:]')
+              GHCR_NAMESPACE="${owner}/gow"
             else
               # For branches, we use the repository owner as namespace
               GHCR_NAMESPACE="${{ github.repository_owner }}/gow"


### PR DESCRIPTION
When forking I got an Error from the Action 

> Error: buildx failed with: ERROR: failed to build: failed to solve: failed to configure registry cache exporter: invalid reference format: repository name (Skerga/gow/base) must be lowercase

So I added a small step that ensures that `github.repository_owner` and `github.event.pull_request.head.repo.owner.login` are converted to lowercase.