### PR TITLE
Add Citron to Pegasus and base-emu

### DIFF
--- a/apps/pegasus/build/configs/app/metadata.pegasus.txt
+++ b/apps/pegasus/build/configs/app/metadata.pegasus.txt
@@ -7,6 +7,7 @@ files:
   /bin/download_pegasus_themes.sh
   /Applications/launchers/dolphin.sh
   /Applications/launchers/xemu.sh
+  /Applications/launchers/citron.sh
   /Applications/launchers/rpcs3.sh
   /bin/Install_RPCS3_Firmware.sh
   /usr/bin/kitty
@@ -34,6 +35,11 @@ game: Emulators - RetroArch
 release: 2023-09-22
 file: /Applications/launchers/retroarch.sh
 description: RetroArch is a frontend for emulators, game engines and media players. It enables you to run classic games on a wide range of computers and consoles through its slick graphical interface. Settings are also unified so configuration is done once and for all. In addition to this, you are able to run original game discs (CDs) from RetroArch.
+
+game: Emulators - Citron
+release: 2025-08-01
+file: /Applications/launchers/citron.sh
+description: Citron is a high-performance, homebrew-focused Nintendo Switch emulator.
 
 game: Emulators - RPCS3
 release: 2023-09-22

--- a/images/base-emu/build/Dockerfile
+++ b/images/base-emu/build/Dockerfile
@@ -91,6 +91,9 @@ github_download "cemu-project/Cemu" "cemu-emu.AppImage" "" "/latest"
 echo "**** Downloading Dolphin AppImage ****"
 github_download "pkgforge-dev/Dolphin-emu-AppImage" "dolphin-emu.AppImage" "|select(.name|contains(\"dwarfs-x86_64\"))"
 
+echo "**** Downloading Citron Emulator AppImage ****"
+github_download "pkgforge-dev/Citron-AppImage" "citron.AppImage" "|select(.name|contains(\"anylinux-x86_64_v3\"))"
+
 echo "**** Downloading Xenia Canary ****"
 github_download "xenia-canary/xenia-canary-releases" "xenia_canary_linux.tar.gz" "" ""
 

--- a/images/base-emu/build/launchers/citron.sh
+++ b/images/base-emu/build/launchers/citron.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+source /opt/gow/bash-lib/utils.sh
+
+gow_log "Starting Citron with DISPLAY=${DISPLAY}"
+/Applications/citron.AppImage --appimage-extract-and-run "$@"

--- a/images/base-emu/build/launchers/rom_launcher.sh
+++ b/images/base-emu/build/launchers/rom_launcher.sh
@@ -86,6 +86,7 @@ declare -A EMULATOR_COMMAND=( \
 ["scummvm"]="launch_scummvm \"${ROM}\"" \
 ["snes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/snes9x_libretro.so \"${ROM}\"" \
 ["snes_widescreen"]="retroarch --fullscreen -L ~/.config/retroarch/cores/bsnes_hd_beta_libretro.so \"${ROM}\"" \
+["switch"]="/Applications/launchers/citron.sh -f -g \"${ROM}\"" \
 ["virtualboy"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_vb_libretro.so \"${ROM}\"" \
 ["wii"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
 ["wiiu"]="/Applications/cemu-emu.AppImage --appimage-extract-and-run -f -g \"${ROM}\"" \


### PR DESCRIPTION
This PR adds Citron to Pegasus and base-emu. Citron is a Switch emulator.

Please note:
I also tested with "Eden" (fork) which as I read on reddit, is a better version of the same emulator, but that one would "segfault" on start, no matter if the legacy or modern version was chosen. Citron is perfectly stable and still maintained.