### PR TITLE
Add libgl1:i386 to Lutris Dockerfile dependencies

### DIFF
--- a/apps/lutris/build/Dockerfile
+++ b/apps/lutris/build/Dockerfile
@@ -20,6 +20,7 @@ ARG REQUIRED_PACKAGES=" \
      libasound2-plugins:i386 \
      libdbus-1-3:i386 \
      libfreetype6:i386 \
+     libgl1:i386 \
      libsdl2-2.0-0:i386 \
      libsqlite3-0:i386 \
      libvulkan1 \


### PR DESCRIPTION
Fix `libGl.so.1` missing, to support old OpenGL 32-bit games