### PR TITLE
Citron fix

### DIFF
--- a/images/base-emu/build/Dockerfile
+++ b/images/base-emu/build/Dockerfile
@@ -117,7 +117,7 @@ echo "**** Downloading Dolphin AppImage ****"
 github_download "pkgforge-dev/Dolphin-emu-AppImage" "dolphin-emu.AppImage" "|select(.name|contains(\"dwarfs-x86_64\"))"
 
 echo "**** Downloading Citron Emulator AppImage ****"
-gitlab_download "https://git.citron-emu.org/citron/emu" "citron.AppImage" "x86_64_v3"
+gitlab_download "https://git.citron-emu.org/citron/emu" "citron.AppImage" "x86_64"
 
 echo "**** Downloading Xenia Canary ****"
 github_download "xenia-canary/xenia-canary-releases" "xenia_canary_linux.tar.gz" "" ""


### PR DESCRIPTION
The Citron v3 AppImage doesn't execute within the docker containers. After some debugging, I found that the normal AppImage works.

Issue: https://github.com/games-on-whales/gow/issues/261

https://github.com/user-attachments/assets/9d0d69e2-301f-4cc8-baa9-b1d6ce48e5b4

