### PR TITLE
fix missing shell when installing nvidia as podman quadlets

### DIFF
--- a/images/nvidia-driver/Dockerfile
+++ b/images/nvidia-driver/Dockerfile
@@ -16,3 +16,4 @@ FROM scratch
 
 COPY --from=nvidia-installer /usr/nvidia/ /usr/nvidia
 COPY --from=nvidia-installer /etc/vulkan/icd.d/nvidia_icd.json /usr/nvidia/share/vulkan/icd.d/
+COPY --from=nvidia-installer /bin/sh /bin/sh


### PR DESCRIPTION
Fixing https://github.com/games-on-whales/gow/issues/264