### PR TITLE
fixes decky loader on ubuntu steam image

### DIFF
--- a/apps/steam/build/scripts/system-services.sh
+++ b/apps/steam/build/scripts/system-services.sh
@@ -19,8 +19,8 @@ gow_log "*** D-Bus Watchdog started ***"
 if [ ! -f "$HOME/homebrew/services/PluginLoader" ]; then
   gow_log "Installing Decky Loader"
   mkdir -p "$HOME/.steam/steam/"
-  mkdir -p "$HOME/.steam/debian-installation/"
-  touch "$HOME/.steam/debian-installation/.cef-enable-remote-debugging"
+  touch "$HOME/.steam/.cef-enable-remote-debugging"
+  ln -s "$HOME/.steam/compatibilitytools.d" "$HOME/.steam/steam/compatibilitytools.d"
   mkdir -p "$HOME/homebrew/services/"
   github_download "SteamDeckHomebrew/decky-loader" ".assets[]|select(.name|(\"PluginLoader\")).browser_download_url" "PluginLoader"
   chmod +x PluginLoader

--- a/apps/steam/build/scripts/system-services.sh
+++ b/apps/steam/build/scripts/system-services.sh
@@ -20,7 +20,7 @@ if [ ! -f "$HOME/homebrew/services/PluginLoader" ]; then
   gow_log "Installing Decky Loader"
   mkdir -p "$HOME/.steam/steam/"
   touch "$HOME/.steam/.cef-enable-remote-debugging"
-  ln -s "$HOME/.steam/compatibilitytools.d" "$HOME/.steam/steam/compatibilitytools.d"
+  ln -fs --no-target-directory "$HOME/.steam/compatibilitytools.d" "$HOME/.steam/steam/compatibilitytools.d"
   mkdir -p "$HOME/homebrew/services/"
   github_download "SteamDeckHomebrew/decky-loader" ".assets[]|select(.name|(\"PluginLoader\")).browser_download_url" "PluginLoader"
   chmod +x PluginLoader


### PR DESCRIPTION
A small PR to fix decky loader under the current ubuntu image compilentary changes have been suggested under https://github.com/games-on-whales/gow/pull/305 to fix it for the fedora variant too.
This won't fix the update issues with decky loader trough right now you still need to delete decky loader in the homebrew directory so it installs it again for updates to be applied.

Keep in mind i haven't build the images for testing yet but i have made the same modifications to my local profile-data/user/WolfSteam directory to get these to work.

- Removes Redundant directory debian-installation
- Creates .cfe-enable-remote-debugging in correct location
- Adds Symlink for compatibilitytools.d since WineCeller expects it to be under .steam/steam
