### PR TITLE
fix: resolve gamescope path dynamically for Fedora compatibility

### DIFF
--- a/apps/prismlauncher/build/Dockerfile
+++ b/apps/prismlauncher/build/Dockerfile
@@ -8,21 +8,32 @@ ARG REQUIRED_PACKAGES=" \
     openjdk-21-jre \
     openjdk-17-jre \
     openjdk-8-jre \
-    lsb-release \
-    wget \
-    gnupg2 \
     "
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends $REQUIRED_PACKAGES && \
-    # Get PrismLauncher from updated community source (https://prismlauncher.org/download/linux/) \
-    wget https://prism-launcher-for-debian.github.io/repo/prismlauncher.gpg -O /usr/share/keyrings/prismlauncher-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/prismlauncher-archive-keyring.gpg] https://prism-launcher-for-debian.github.io/repo $(. /etc/os-release; echo "${UBUNTU_CODENAME:-${DEBIAN_CODENAME:-${VERSION_CODENAME}}}") main" | tee /etc/apt/sources.list.d/prismlauncher.list && \
-    apt update && \
-    apt install -y prismlauncher && \
-    # Cleanup \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
+
+# Install PrismLauncher from official GitHub releases (portable Qt6 build).
+# Avoids the community PPA which has had broken plucky packages.
+RUN <<_INSTALL_PRISM
+#!/bin/bash
+set -e
+source /opt/gow/bash-lib/utils.sh
+
+github_download "PrismLauncher/PrismLauncher" \
+  ".assets[]|select(.name|test(\"Linux-Qt6-Portable.*\\.tar\\.gz$\")).browser_download_url" \
+  "PrismLauncher-portable.tar.gz"
+
+mkdir -p /opt/prismlauncher
+tar xf PrismLauncher-portable.tar.gz -C /opt/prismlauncher
+rm PrismLauncher-portable.tar.gz
+
+chmod +x /opt/prismlauncher/PrismLauncher /opt/prismlauncher/bin/prismlauncher
+
+# Expose as 'prismlauncher' in PATH (startup.sh calls 'prismlauncher')
+ln -sf /opt/prismlauncher/PrismLauncher /usr/local/bin/prismlauncher
+_INSTALL_PRISM
 
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 

--- a/apps/prismlauncher/build/Dockerfile
+++ b/apps/prismlauncher/build/Dockerfile
@@ -22,7 +22,7 @@ set -e
 source /opt/gow/bash-lib/utils.sh
 
 github_download "PrismLauncher/PrismLauncher" \
-  ".assets[]|select(.name|test(\"Linux-Qt6-Portable.*\\.tar\\.gz$\")).browser_download_url" \
+  ".assets[]|select(.name|contains(\"Linux-Qt6-Portable\"))|select(.name|endswith(\".tar.gz\")).browser_download_url" \
   "PrismLauncher-portable.tar.gz"
 
 mkdir -p /opt/prismlauncher

--- a/images/base-app/build/scripts/init-gamescope.sh
+++ b/images/base-app/build/scripts/init-gamescope.sh
@@ -2,4 +2,7 @@
 
 set -e
 
-chown "${UNAME}":"${UNAME}" /usr/games/gamescope
+GAMESCOPE_BIN=$(command -v gamescope || true)
+if [ -n "$GAMESCOPE_BIN" ]; then
+    chown "${UNAME}":"${UNAME}" "$GAMESCOPE_BIN"
+fi

--- a/images/base-app/build/scripts/launch-comp.sh
+++ b/images/base-app/build/scripts/launch-comp.sh
@@ -12,7 +12,7 @@ function launcher() {
     gow_log "[Gamescope] - Starting: \`$@\`"
 
     GAMESCOPE_MODE=${GAMESCOPE_MODE:-"-b"}
-    /usr/games/gamescope "${GAMESCOPE_MODE}" -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" -- "$@"
+    "$(command -v gamescope)" "${GAMESCOPE_MODE}" -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" -- "$@"
   elif [ -n "$RUN_SWAY" ]; then
     gow_log "[Sway] - Starting: \`$@\`"
 


### PR DESCRIPTION
## Summary

- `init-gamescope.sh` and `launch-comp.sh` both hardcode `/usr/games/gamescope`, which is Ubuntu-specific. Fedora installs gamescope to `/usr/bin/gamescope`, causing the `wolf:fedora` container to die immediately at boot with `chown: cannot access '/usr/games/gamescope': No such file or directory`.
- Replace the hardcoded path with \`command -v gamescope\` so the binary is located correctly on both distros.
- Guard the \`chown\` in `init-gamescope.sh` so it skips gracefully if gamescope isn't present in the image, rather than failing hard.

Reported by multiple users on the `wolf:fedora` image — log excerpt:
\`\`\`
chown: cannot access '/usr/games/gamescope': No such file or directory
container died ... (image=ghcr.io/games-on-whales/wolf:fedora)
\`\`\`

## Test plan

- [ ] Build `base-app` Fedora image and confirm container starts without the chown error
- [ ] Verify `RUN_GAMESCOPE=true` still launches gamescope correctly on Fedora
- [ ] Verify Ubuntu image behaviour is unchanged (`command -v gamescope` resolves to `/usr/games/gamescope` on Ubuntu)