### PR TITLE
fix(fedora): apply PR #310 gamescope-path fix to base-app Fedora variant

### DIFF
--- a/images/base-app/build-fedora/Dockerfile
+++ b/images/base-app/build-fedora/Dockerfile
@@ -63,8 +63,5 @@ COPY --from=sdl-jstest-builder /sdl-jstest/build/sdl2-jstest /usr/local/bin/sdl2
 # Fix Sway cap_sys_nice=ep
 RUN setcap -r /usr/sbin/sway
 
-# Add /usr/games/ to $PATH in order to be able to run gamescope
-ENV PATH="/usr/games/:${PATH}"
-
 # Configure the default directory to be the 'retro' users home directory
 WORKDIR ${HOME}

--- a/images/base-app/build-fedora/scripts/init-gamescope.sh
+++ b/images/base-app/build-fedora/scripts/init-gamescope.sh
@@ -2,4 +2,7 @@
 
 set -e
 
-chown "${UNAME}":"${UNAME}" $(which gamescope)
+GAMESCOPE_BIN=$(command -v gamescope || true)
+if [ -n "$GAMESCOPE_BIN" ]; then
+    chown "${UNAME}":"${UNAME}" "$GAMESCOPE_BIN"
+fi

--- a/images/base-app/build-fedora/scripts/launch-comp.sh
+++ b/images/base-app/build-fedora/scripts/launch-comp.sh
@@ -12,7 +12,7 @@ function launcher() {
     gow_log "[Gamescope] - Starting: \`$@\`"
 
     GAMESCOPE_MODE=${GAMESCOPE_MODE:-"-b"}
-    gamescope "${GAMESCOPE_MODE}" -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" -- "$@"
+    "$(command -v gamescope)" "${GAMESCOPE_MODE}" -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" -- "$@"
   elif [ -n "$RUN_SWAY" ]; then
     gow_log "[Sway] - Starting: \`$@\`"
 


### PR DESCRIPTION
## Summary
PR #310 (already merged into #305) fixed the `/usr/games/gamescope` hardcoded path only in `images/base-app/build/scripts/` (the Ubuntu variant). The Fedora copies under `images/base-app/build-fedora/scripts/` were missed, so the latest `:fedora-43` images still ship a broken `init-gamescope.sh`.

## What's broken on `:fedora-43` today
- `images/base-app/build-fedora/scripts/init-gamescope.sh` runs `chown ... \$(which gamescope)`. The Fedora base image (`quay.io/fedora/fedora:43` + the small package set in `images/base/build-fedora/Dockerfile`) does **not** ship the `which` binary. So:
  - `\$(which gamescope)` expands to empty
  - `chown` errors with `missing operand`
  - `set -e` aborts the cont-init.d step → container init fails
- `images/base-app/build-fedora/scripts/launch-comp.sh` calls bare `gamescope` (works today, but the Ubuntu version was hardened to `"\$(command -v gamescope)"` in #310 — keep them in sync).
- `images/base-app/build-fedora/Dockerfile` still adds `/usr/games/` to `PATH` with a matching comment, even though Fedora installs gamescope to `/usr/bin/gamescope`. Pure Ubuntu-ism, drop it.

## Changes
- `init-gamescope.sh`: resolve via `command -v gamescope` and skip the `chown` if the binary is absent — same pattern as PR #310.
- `launch-comp.sh`: use `"\$(command -v gamescope)"` to mirror the Ubuntu variant.
- `Dockerfile`: drop `ENV PATH="/usr/games/:\${PATH}"` and its comment.

## Note for users still hitting this
Anyone reporting the original `/usr/games/gamescope: no such file or directory` on `:fedora-43` *after* this lands should `docker pull` to refresh — registry/BuildKit cache pollution has bitten this PR before (see `e8622d4` and `ca6dcb2`), so the Dockerfile edit here also helps invalidate the cached COPY layer.

## Targeting
This PR targets `fedora-variant-images` (#305), not `master`, so it lands as part of the Fedora rollout rather than chasing master separately.

## Test plan
- [ ] CI builds `base-app:fedora-43` cleanly with the new `init-gamescope.sh`.
- [ ] `steam:fedora-43` boots without dying in cont-init.d.
- [ ] `RUN_GAMESCOPE=true` and `RUN_SWAY=true` both still launch via `launch-comp.sh`.