### PR TITLE
steam: resolve gamescope path dynamically on Fedora

### DIFF
--- a/apps/steam/build/scripts/startup.sh
+++ b/apps/steam/build/scripts/startup.sh
@@ -56,6 +56,8 @@ export GTK_IM_MODULE=Steam
 
 
 if [ -n "$RUN_GAMESCOPE" ]; then
+  GAMESCOPE_BIN="$(command -v gamescope)"
+
   # Enable support for xwayland isolation per-game in Steam
   # Note: This breaks without the additional steamdeck flags
   #export STEAM_MULTIPLE_XWAYLANDS=1
@@ -98,7 +100,7 @@ if [ -n "$RUN_GAMESCOPE" ]; then
   GAMESCOPE_MODE=${GAMESCOPE_MODE:-"-b"}
 
   # shellcheck disable=SC2086
-  /usr/games/gamescope -e ${GAMESCOPE_MODE} -R $socket -T $stats -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" &
+  "${GAMESCOPE_BIN}" -e ${GAMESCOPE_MODE} -R $socket -T $stats -W "${GAMESCOPE_WIDTH}" -H "${GAMESCOPE_HEIGHT}" -r "${GAMESCOPE_REFRESH}" &
 
   # Read the variables we need from the socket
   if read -r -t 3 response_x_display response_wl_display <> "$socket"; then


### PR DESCRIPTION
## Summary
Resolves the Steam startup script's hardcoded /usr/games/gamescope path when running against the Fedora variant work in #305.

## What Changed
- resolve gamescope with command -v inside apps/steam/build/scripts/startup.sh
- use the resolved binary instead of assuming the Debian-specific /usr/games/gamescope path

## Why
Fedora typically installs gamescope under /usr/bin/gamescope, so the hardcoded /usr/games/gamescope path breaks Steam startup on the Fedora image variant from #305.

## Validation
- bash -n images/base-app/build/scripts/init-gamescope.sh
- bash -n images/base-app/build/scripts/launch-comp.sh
- bash -n apps/steam/build/scripts/startup.sh