### PR TITLE
es-de: pin AppImage download to x64 variant

### DIFF
--- a/apps/es-de/build/Dockerfile
+++ b/apps/es-de/build/Dockerfile
@@ -16,7 +16,7 @@ RUN \
         mkdir -p /tmp && \
         cd /tmp && \
         curl https://gitlab.com/api/v4/projects/18817634/releases | \
-        jq '.[0].assets.links[]|select(.name|endswith(".AppImage"))|select(.name|contains("SteamDeck")|not).direct_asset_url' | \
+        jq -r '.[0].assets.links[]|select(.name=="ES-DE_x64.AppImage").direct_asset_url' | \
         xargs wget -O /Applications/esde.AppImage && \
         chmod -v -R 777 /Applications/esde.AppImage && \
     	chmod -v -R a+x /Applications/esde.AppImage


### PR DESCRIPTION
## Summary
- Upstream ES-DE releases now ship three AppImages (`ES-DE_x64_SteamDeck.AppImage`, `ES-DE_aarch64.AppImage`, `ES-DE_x64.AppImage`). The existing jq filter only excluded `SteamDeck`, so `xargs wget -O /Applications/esde.AppImage` received two URLs and concatenated both downloads into a single file.
- The resulting binary is unparseable, producing `sh: 1: /Applications/esde.AppImage: Exec format error` at launch.
- Tighten the filter to match `ES-DE_x64.AppImage` by exact name (es-de is amd64-only per `.github/workflows/auto-build.yml`). Also add `jq -r` so the URL is emitted unquoted for `xargs`.

Stacked on #305 so the fedora-variant branch also picks up the fix.

## Test plan
- [ ] Rebuild the `es-de` image and confirm `/Applications/esde.AppImage` is a single valid AppImage (`file` reports ELF, not concatenated content).
- [ ] Launch ES-DE via Sway and confirm it starts without the `Exec format error`.