### PR TITLE
prismlauncher: fix /opt/prismlauncher permission error by redirecting data dir to $HOME

### DIFF
--- a/apps/prismlauncher/build/scripts/startup.sh
+++ b/apps/prismlauncher/build/scripts/startup.sh
@@ -2,7 +2,12 @@
 
 source /opt/gow/bash-lib/utils.sh
 
-PrismLauncher=prismlauncher
+# The portable Qt6 build treats its install dir (/opt/prismlauncher) as the
+# data folder, which isn't writable by the runtime user and wouldn't persist
+# across container restarts. Point it at $HOME/.local/share/PrismLauncher so
+# instances/logs live with the rest of the user's persistent state.
+PRISM_DATA_DIR="${HOME}/.local/share/PrismLauncher"
+mkdir -p "${PRISM_DATA_DIR}"
 
 # Run additional startup scripts
 for file in /opt/gow/startup.d/* ; do
@@ -15,4 +20,4 @@ done
 gow_log "[start] Starting PrismLauncher"
 
 source /opt/gow/launch-comp.sh
-launcher "${PrismLauncher}"
+launcher prismlauncher -d "${PRISM_DATA_DIR}"


### PR DESCRIPTION
## Summary
- Fixes #314 — PrismLauncher fails to start with `couldn't create a log file ... Make sure you have write permissions to the data folder. (/opt/prismlauncher)`.
- Root cause: commit `ad24ec5` switched from the APT package to the official Qt6 Portable tarball. Portable PrismLauncher uses its install dir (`/opt/prismlauncher`) as the data folder, but that path is owned by root after extraction, so the runtime user (`retro`, dynamic UID) can't write logs there.
- Secondary problem the same change introduced: user data (Minecraft instances/worlds) written to `/opt/prismlauncher` wouldn't persist across container restarts. The APT package previously stored data under `~/.local/share/PrismLauncher`, which lives in the persistent `$HOME`.
- Fix: pass `-d "$HOME/.local/share/PrismLauncher"` (created via `mkdir -p`) from `startup.sh`. Both problems resolved with one change — logs land in a writable dir, and instances survive restarts.

## Test plan
- [ ] Rebuild `ghcr.io/games-on-whales/prismlauncher:edge` from this branch.
- [ ] Launch via Wolf; confirm PrismLauncher opens (no "write permissions" error).
- [ ] Create a Minecraft instance, exit, recreate the container, confirm the instance is still there under `$HOME/.local/share/PrismLauncher/instances`.
- [ ] Confirm `/opt/prismlauncher` is not being written to at runtime.