### PR TITLE
xfce: fix Fedora dnf install and wire Flathub into gnome-software

### DIFF
--- a/apps/xfce/build-fedora/Dockerfile
+++ b/apps/xfce/build-fedora/Dockerfile
@@ -4,33 +4,44 @@ ARG BASE_APP_IMAGE=ghcr.io/games-on-whales/base-app:fedora
 # hadolint ignore=DL3006
 FROM ${BASE_APP_IMAGE}
 
+# NOTE: do not insert `# ... \` comments between continued lines — bash treats
+# them as a comment that swallows the continuation, which breaks `dnf install`.
 RUN dnf install -y \
-    # Core \
-    wget \
-    dbus-x11 \
-    flatpak \
-    sudo \
-    # Desktop environment \
-    @xfce-desktop-environment \
-    xfce4-settings \
-    papirus-icon-theme arc-theme \
-    at-spi2-core \
-    # Additional apps \
-    xfce4-terminal \
-    xfce4-taskmanager \
-    xfce4-whiskermenu-plugin \
-    xfce4-docklike-plugin \
-    xarchiver \
-    mousepad \
-    zip unzip p7zip \
-    gnome-software \
-    # Browser \
-    firefox \
+        wget \
+        dbus-x11 \
+        flatpak \
+        sudo \
+        @xfce-desktop-environment \
+        xfce4-settings \
+        papirus-icon-theme arc-theme \
+        at-spi2-core \
+        xfce4-terminal \
+        xfce4-taskmanager \
+        xfce4-whiskermenu-plugin \
+        xfce4-docklike-plugin \
+        xarchiver \
+        mousepad \
+        zip unzip p7zip \
+        gnome-software \
+        dconf \
+        firefox \
     && { dnf remove -y foot 2>/dev/null || true; } \
+    && rm -f /etc/xdg/autostart/xscreensaver.desktop \
     && dnf clean all
 
-# Remove xscreensaver autostart if present
-RUN rm -f /etc/xdg/autostart/xscreensaver.desktop
+# Register Flathub as a system remote and pre-seed AppStream metadata so
+# gnome-software surfaces flatpak apps on first launch (without this the
+# Software manager only shows rpm results and hides flathub entirely).
+RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo \
+    && flatpak remote-modify --enable flathub \
+    && flatpak --system update --appstream --noninteractive || true
+
+# Make gnome-software prefer flatpak over rpm for app installs.
+RUN mkdir -p /etc/dconf/db/local.d /etc/dconf/profile \
+    && printf 'user-db:user\nsystem-db:local\n' > /etc/dconf/profile/user \
+    && printf "[org/gnome/software]\npackaging-format-preference=['flatpak', 'rpm']\n" \
+        > /etc/dconf/db/local.d/00-gnome-software-prefer-flatpak \
+    && dconf update
 
 # Replace launch scripts
 COPY --chmod=777 scripts/launch-comp.sh scripts/startup.sh /opt/gow/


### PR DESCRIPTION
## Summary
Fixes two real problems with the Fedora XFCE image on #305:

- The `dnf install` block in `apps/xfce/build-fedora/Dockerfile` used inline `# comment \` lines between continued arguments. Bash treats the `#` as a comment that consumes the trailing backslash, so the continuation breaks and most of the package list runs as separate (failing) commands. Collapsed the comments out of the continuation so the full list reaches `dnf`.
- gnome-software didn't pick up Flathub and defaulted to dnf installs. Registered Flathub as a **system** remote, pre-seeded its AppStream metadata at build time (without this flathub apps don't appear in the Software UI on first launch), and dropped a dconf override setting `packaging-format-preference=['flatpak', 'rpm']` so gnome-software prefers flatpak when both backends offer the same app.

Also pulls in `dconf` explicitly so the override compiles during build.

## Test plan
- [ ] CI builds `xfce:fedora` (`auto-build.yml` Fedora chain) successfully
- [ ] Launch the XFCE Fedora app in Wolf; open "Software" and confirm Flathub apps are listed
- [ ] Install an app from Software and confirm it lands as a flatpak (e.g. in `/var/lib/flatpak/app/...`), not a dnf package
- [ ] `flatpak remote-list --system` shows `flathub` in the running container