### PR TITLE
base-app: resolve gamescope path dynamically in init-gamescope

### DIFF
--- a/images/base-app/build/scripts/init-gamescope.sh
+++ b/images/base-app/build/scripts/init-gamescope.sh
@@ -2,4 +2,7 @@
 
 set -e
 
-chown "${UNAME}":"${UNAME}" /usr/games/gamescope
+GAMESCOPE_BIN=$(command -v gamescope || true)
+if [ -n "$GAMESCOPE_BIN" ]; then
+    chown "${UNAME}":"${UNAME}" "$GAMESCOPE_BIN"
+fi


### PR DESCRIPTION
## Summary

The Ubuntu `base-app` image's `init-gamescope.sh` hardcodes `/usr/games/gamescope`. Images downstream of it — notably `ghcr.io/games-on-whales/wolf:fedora-43`, which ingests `/etc/cont-init.d/` out of the Ubuntu builder stage — inherit this path even on Fedora, where `gamescope` lives at `/usr/bin/gamescope`. With `set -e`, the `chown` then aborts the entire container entrypoint before Wolf (or any other downstream app) gets a chance to start.

This mirrors the defensive form already in `build-fedora/scripts/init-gamescope.sh` from PRs #310, #311, and #312 — resolve the binary via `command -v` and skip cleanly when it isn't installed. No behavior change on the Ubuntu target, where `gamescope` is still at `/usr/games/gamescope`.

## Test plan

- [x] Reproduce: run `ghcr.io/games-on-whales/wolf:fedora-43` on a stock Fedora 43 host; `init-gamescope.sh` fails at `chown: cannot access '/usr/games/gamescope'`, killing the entrypoint.
- [x] With this script bind-mounted over the failing one inside the wolf container, init-gamescope becomes a no-op and Wolf proceeds past init.
- [ ] CI green on the Ubuntu build (no functional change there).