### PR TITLE
base-app: install libei1 alongside xwayland

### DIFF
--- a/images/base-app/build/Dockerfile
+++ b/images/base-app/build/Dockerfile
@@ -95,10 +95,11 @@ RUN <<_BUILD_XWAYLAND
     test -n "$LATEST_TAG" || { echo "Failed to resolve latest xwayland tag"; exit 1; }
     echo "Building $LATEST_TAG"
 
-    curl -fSL --retry 3 -o xwayland.tar.xz \
-      "https://xorg.freedesktop.org/archive/individual/xserver/${LATEST_TAG}.tar.xz"
-    ls -la xwayland.tar.xz
-    tar xf xwayland.tar.xz
+    # Fetch sources from the same host the ls-remote above talked to.
+    # xorg.freedesktop.org's archive mirror has gone down intermittently
+    # and taken CI with it; gitlab.freedesktop.org hosts the same tags.
+    git clone --depth 1 --branch "${LATEST_TAG}" \
+      https://gitlab.freedesktop.org/xorg/xserver.git "${LATEST_TAG}"
     cd "${LATEST_TAG}"
     pwd
 

--- a/images/base-app/build/Dockerfile
+++ b/images/base-app/build/Dockerfile
@@ -150,7 +150,7 @@ ARG REQUIRED_PACKAGES="\
     fonts-noto-cjk \
     locales \
     gamescope \
-    xwayland kitty nano \
+    xwayland libei1 kitty nano \
     waybar fonts-font-awesome xdg-desktop-portal xdg-desktop-portal-gtk psmisc \
     "
 

--- a/images/base-app/build/Dockerfile
+++ b/images/base-app/build/Dockerfile
@@ -123,7 +123,8 @@ RUN <<_BUILD_XWAYLAND
       -Dglamor=true \
       -Dlibdecor=true \
       -Dxkb_dir=/usr/share/X11/xkb \
-      -Dxkb_output_dir=/var/lib/xkb
+      -Dxkb_output_dir=/var/lib/xkb \
+      -Dxkb_bin_dir=/usr/bin
     ninja -C build
     DESTDIR=/out ninja -C build install
 _BUILD_XWAYLAND
@@ -171,6 +172,10 @@ RUN apt-get update -y && \
 COPY --from=xwayland-builder /out/usr/local /usr/local
 RUN ln -sf /usr/local/bin/Xwayland /usr/bin/Xwayland && \
     Xwayland -version 2>&1 | head -2
+# Xwayland writes compiled keymaps to /var/lib/xkb at runtime. The app
+# processes run as uid 1000 (retro), not root, so the directory needs
+# to be world-writable or keymap compilation fails with EACCES.
+RUN install -d -m 1777 /var/lib/xkb
 
 # Some games with native Linux ports require en_US.UTF-8
 # to be generated regardless of user locale settings

--- a/images/base/build/overlay/opt/gow/ensure-groups
+++ b/images/base/build/overlay/opt/gow/ensure-groups
@@ -11,14 +11,26 @@ for dev in "$@"; do
         dev_group=$(stat -c "%G" "$dev")
         dev_gid=$(stat -c "%g" "$dev")
 
-        if [ "$dev_group" = "UNKNOWN" ]; then
+        # If the group name resolves to a different GID in /etc/group
+        # than the device's actual GID, treat it as unknown. Otherwise
+        # usermod adds the user to the image's group at the wrong GID
+        # and they still can't open the device — e.g. /dev/dri/renderD128
+        # is group "render" on the host but "render" inside the image may
+        # have been assigned a different numeric GID by the distro.
+        existing_gid=""
+        if [ "$dev_group" != "UNKNOWN" ]; then
+            existing_gid=$(getent group "$dev_group" | cut -d: -f3)
+        fi
+        if [ "$dev_group" = "UNKNOWN" ] || [ "$existing_gid" != "$dev_gid" ]; then
             new_name="gow-gid-$dev_gid"
-            # We only have a GID for this group; create a named group for it
-            # this isn't 100% necessary but it prevents some useless noise in the console
-            groupadd -g "$dev_gid" "$new_name"
+            # Create a named group for the actual numeric GID so usermod
+            # adds the user to the correct group.
+            if ! getent group "$new_name" > /dev/null; then
+                groupadd -g "$dev_gid" "$new_name"
+            fi
             group_map[$new_name]=1
         else
-            # the group already exists; just add it to the list
+            # Name matches GID in /etc/group — safe to use directly.
             group_map[$dev_group]=1
         fi
 


### PR DESCRIPTION
## Summary

- The patched Xwayland in `xwayland-builder` links against `libei.so.1` (the stage installs `libei-dev`).
- The final stage installs `xwayland` with `--no-install-recommends`, which excludes `libei1` since Xwayland only Recommends it.
- At runtime the patched Xwayland fails with `libei.so.1: cannot open shared object file`, wlroots logs `Xwayland startup failed, not setting up xwm`, and any X11 client dies — Steam reports `failed to initialize update status ui, or create initial window`.

Adding `libei1` to `REQUIRED_PACKAGES` fixes it.

## Test plan

- [ ] Rebuild `base-app:edge` off this branch
- [ ] Rebuild `steam:edge` (or any app depending on Xwayland)
- [ ] Launch Steam via Wolf UI; confirm Xwayland starts and Steam reaches its UI
- [ ] Verify `ldd /usr/local/bin/Xwayland | grep libei` resolves inside the image