### PR TITLE
fixing migration script for legacy steam installations moving to fedora.

### DIFF
--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -18,7 +18,7 @@ gow_log "*** D-Bus Watchdog started ***"
 STEAMDIR="${HOME}/.local/share/Steam"
 STEAMDIR_LEGACY="${HOME}/.steam/steam"
 # Is the user coming from an Ubuntu installation?
-if [ ! -h "$STEAMDIR_LEGACY" ]; then
+if [ -d "${HOME}/.steam" ] && [ ! -h "$STEAMDIR_LEGACY" ]; then
   gow_log "*** Steam Legacy detected, moving steamapps to the new location ***"
   # -rf: on a fresh Fedora profile $STEAMDIR may not exist yet; rm -r
   # aborted the cont-init script with "No such file or directory" and

--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -28,7 +28,7 @@ if [ ! -h "$STEAMDIR_LEGACY" ]; then
   rm -rf "$STEAMDIR"
   mv "$STEAMDIR_LEGACY" "$STEAMDIR"
   rm -rf "${HOME}/.steam/steam"
-  ln -s ${STEAMDIR} ${STEAMDIR_LEGACY}
+  ln -fs ${STEAMDIR} ${STEAMDIR_LEGACY}
 fi
 
 # Install Decky Loader

--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -28,7 +28,7 @@ if [ ! -h "$STEAMDIR_LEGACY" ]; then
   rm -rf "$STEAMDIR"
   mv "$STEAMDIR_LEGACY" "$STEAMDIR"
   rm -rf "${HOME}/.steam/steam"
-  ln -fs ${STEAMDIR} ${STEAMDIR_LEGACY}
+  ln -fs --no-target-directory ${STEAMDIR} ${STEAMDIR_LEGACY}
 fi
 
 # Install Decky Loader

--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -16,9 +16,9 @@ steamos-dbus-watchdog.sh &
 gow_log "*** D-Bus Watchdog started ***"
 
 STEAMDIR="${HOME}/.local/share/Steam"
-STEAMDIR_LEGACY="${HOME}/.steam/debian-installation"
+STEAMDIR_LEGACY="${HOME}/.steam/steam"
 # Is the user coming from an Ubuntu installation?
-if [ -d "$STEAMDIR_LEGACY" ]; then
+if [ ! -h "$STEAMDIR_LEGACY" ]; then
   gow_log "*** Steam Legacy detected, moving steamapps to the new location ***"
   # -rf: on a fresh Fedora profile $STEAMDIR may not exist yet; rm -r
   # aborted the cont-init script with "No such file or directory" and
@@ -27,7 +27,8 @@ if [ -d "$STEAMDIR_LEGACY" ]; then
   # failed runs.
   rm -rf "$STEAMDIR"
   mv "$STEAMDIR_LEGACY" "$STEAMDIR"
-  rm -rf "${HOME}/.steam/"
+  rm -rf "${HOME}/.steam/steam"
+  ln -s ${STEAMDIR} ${STEAMDIR_LEGACY}
 fi
 
 # Install Decky Loader

--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -27,8 +27,7 @@ if [ ! -h "$STEAMDIR_LEGACY" ]; then
   # failed runs.
   rm -rf "$STEAMDIR"
   mv "$STEAMDIR_LEGACY" "$STEAMDIR"
-  rm -rf "${HOME}/.steam/steam"
-  ln -fs --no-target-directory ${STEAMDIR} ${STEAMDIR_LEGACY}
+  rm -rf "${HOME}/.steam"
 fi
 
 # Install Decky Loader


### PR DESCRIPTION
This should fix the issue with migrating from ubuntu to fedora steam profiles.
From what i have learned testing the script manually it should work however steam will still cleanup your compatabilitytools.d direcctory that probably happens during the first setup of steam on fedora and is not avoidable.

Mind you i have only run the commands on my profile-data manually not build the container image.