### PR TITLE
steam-fedora: stop migration loop wiping login state every boot

### DIFF
--- a/apps/steam/build-fedora/scripts/steam.sh
+++ b/apps/steam/build-fedora/scripts/steam.sh
@@ -9,8 +9,20 @@ if [[ ! -f "$STEAMDIR/steam.sh" ]]; then
     mkdir -p "$STEAMDIR"
     cd "$STEAMDIR"
     tar xJf /usr/lib/steam/bootstraplinux_ubuntu12_32.tar.xz
-    mkdir -p "$STEAMDIR_LEGACY"
-    ln -fns "$STEAMDIR" "$STEAMDIR_LEGACY"
+fi
+
+# Ensure ~/.steam/steam is a symlink to the real Steam directory.
+# Note: do NOT mkdir -p "$STEAMDIR_LEGACY" before this. If the legacy path
+# exists as a real directory, `ln -sfn` cannot replace it and silently
+# nests the link inside as ".steam/steam/Steam", which then fools the
+# migration guard in cont-init/system-services.sh into firing on every boot.
+mkdir -p "$(dirname "$STEAMDIR_LEGACY")"
+if [ -L "$STEAMDIR_LEGACY" ] || [ ! -e "$STEAMDIR_LEGACY" ]; then
+    ln -sfn "$STEAMDIR" "$STEAMDIR_LEGACY"
+elif [ -d "$STEAMDIR_LEGACY" ] && [ -z "$(ls -A "$STEAMDIR_LEGACY" 2>/dev/null)" ]; then
+    rmdir "$STEAMDIR_LEGACY" && ln -sfn "$STEAMDIR" "$STEAMDIR_LEGACY"
+else
+    echo "WARN: $STEAMDIR_LEGACY is a non-empty real directory; refusing to replace with symlink. Manual cleanup required."
 fi
 
 

--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -24,15 +24,21 @@ gow_log "*** D-Bus Watchdog started ***"
 STEAMDIR="${HOME}/.local/share/Steam"
 STEAMDIR_LEGACY="${HOME}/.steam/steam"
 # Is the user coming from an Ubuntu installation?
-if [ -d "${HOME}/.steam" ] && [ ! -h "$STEAMDIR_LEGACY" ]; then
-  gow_log "*** Steam Legacy detected, moving steamapps to the new location ***"
-  # -rf: on a fresh Fedora profile $STEAMDIR may not exist yet; rm -r
-  # aborted the cont-init script with "No such file or directory" and
-  # Steam never started (black screen → session killed). Same for the
-  # legacy /.steam/ cleanup below, which may also be gone after prior
-  # failed runs.
-  rm -rf "$STEAMDIR"
-  mv "$STEAMDIR_LEGACY" "$STEAMDIR"
+#
+# Guards (all must hold) so this only fires for a real legacy migration and
+# never clobbers an already-migrated profile or a bind-mounted $STEAMDIR:
+#   1. legacy path exists as a real directory, not the post-migration symlink
+#   2. it actually contains game data (steamapps/)
+#   3. the new location does not already contain game data
+if [ -d "$STEAMDIR_LEGACY" ] && [ ! -L "$STEAMDIR_LEGACY" ] \
+   && [ -d "$STEAMDIR_LEGACY/steamapps" ] \
+   && [ ! -d "$STEAMDIR/steamapps" ]; then
+  gow_log "*** Steam Legacy detected, migrating steamapps to the new location ***"
+  mkdir -p "$STEAMDIR"
+  # cp -aT then rm: works when $STEAMDIR is a bind mount (mv across
+  # filesystems would fail) and avoids the destructive `rm -rf $STEAMDIR`
+  # that previously wiped login state on every restart.
+  cp -aT "$STEAMDIR_LEGACY" "$STEAMDIR"
   rm -rf "${HOME}/.steam"
 fi
 


### PR DESCRIPTION
## Summary
Fixes the fedora Steam image bug where every container restart asked for a fresh login and shuffled `steamapps` between locations (reported in Discord by Артём; touches the same area as #323).

Two interacting bugs:

1. **`steam.sh` (wrapper)** pre-created `~/.steam/steam` as a real directory, then called `ln -sfn $STEAMDIR $STEAMDIR_LEGACY`. Against an existing real directory, `ln -s` (even with `-fn`) cannot replace it and silently creates the link _inside_ as `~/.steam/steam/Steam`. The legacy path therefore remained a real directory forever.
2. **`system-services.sh` (migration)** guarded only on `[ ! -h $STEAMDIR_LEGACY ]`. Because of (1) that test was always true, so the migration fired every boot:
   - `rm -rf $STEAMDIR` wiped the previous boot's `.local/share/Steam` (login state, `steam.sh`, any data).
   - `mv $STEAMDIR_LEGACY $STEAMDIR` moved the just-recreated broken-shape directory into place.
   - `rm -rf ~/.steam` finished the cycle. Next boot, the wrapper's `if [[ ! -f $STEAMDIR/steam.sh ]]` was true again (we just deleted it), and the loop restarted.

The Ubuntu image is unaffected; only `apps/steam/build-fedora/scripts/` is touched.

### Changes
- **`steam.sh`**: only `mkdir -p` the _parent_ of `STEAMDIR_LEGACY`. Replace an empty or missing target with a symlink; refuse to clobber a non-empty real directory and emit a warning so already-broken profiles can be inspected manually rather than re-broken.
- **`system-services.sh`**: tighten the migration guard to require (a) legacy is a real directory not a symlink, (b) it actually has `steamapps/`, (c) the new location does not. Switch from `rm -rf $STEAMDIR; mv $STEAMDIR_LEGACY $STEAMDIR` to `cp -aT` + cleanup so a bind-mounted `$STEAMDIR` survives and we never destructively wipe an already-populated new location.

### Behavior matrix
| Starting state | Before | After |
| --- | --- | --- |
| Fresh fedora profile | broken-shape `.steam/steam/Steam` symlink, login wiped each restart | proper `.steam/steam -> .local/share/Steam` symlink, login persists |
| Ubuntu legacy with games in `.steam/steam/steamapps` | migrates once, then loops and wipes on every restart | migrates once, idempotent thereafter |
| Already in the broken loop (both locations populated) | continues looping | migration skips (target non-empty); wrapper warns and does not re-create the broken nested link |
| `$STEAMDIR` bind-mounted to host | `rm -rf $STEAMDIR` + `mv` would corrupt mount | `cp -aT` preserves mount semantics |

## Test plan
- [ ] Fresh fedora profile: launch, sign in, install a game, restart container twice — login and game survive, `~/.steam/steam` is a symlink.
- [ ] Simulated Ubuntu legacy: pre-seed `~/.steam/steam/steamapps/<game>`, launch — game appears in new location, `~/.steam` is gone, second restart does not re-migrate.
- [ ] Profile already in broken loop (real `~/.steam/steam` dir with games + populated `.local/share/Steam`): launch — warning logged, no further data shuffling.
- [ ] Bind-mounted `~/.local/share/Steam` from host: legacy migration leaves the mount intact.