### PR TITLE
Add missing packages in fedora base

### DIFF
--- a/images/base-app/build-fedora/Dockerfile
+++ b/images/base-app/build-fedora/Dockerfile
@@ -44,7 +44,7 @@ ARG REQUIRED_PACKAGES="\
     gamescope \
     sway \
     xorg-x11-server-Xwayland kitty nano \
-    waybar default-fonts xdg-desktop-portal xdg-desktop-portal-gtk psmisc \
+    waybar mako default-fonts xdg-desktop-portal xdg-desktop-portal-gtk psmisc \
     mangohud \
     sdl2-compat ncurses \
     dbus-daemon \

--- a/images/base-app/build-fedora/Dockerfile
+++ b/images/base-app/build-fedora/Dockerfile
@@ -47,6 +47,7 @@ ARG REQUIRED_PACKAGES="\
     waybar mako default-fonts xdg-desktop-portal xdg-desktop-portal-gtk psmisc \
     mangohud \
     sdl2-compat ncurses \
+    procps-ng \
     dbus-daemon \
     "
 

--- a/images/base-app/build-fedora/configs/sway/config
+++ b/images/base-app/build-fedora/configs/sway/config
@@ -101,6 +101,8 @@ include /etc/sway/config.d/*
 
 bar swaybar_command waybar
 
+exec mako
+
 # App fixes
 # You can get more info about windows at runtime with `swaymsg -t get_tree`
 # Steam big picture fix (force windowing mode)


### PR DESCRIPTION
Potentially fixes #325. 

It appears that the `free` binary cannot be found inside the container.
This PR adds two new packages `procps-ng` and `mako` to make the binary available and also enable notification.