### PR TITLE
steam: bake Decky Loader at build time (fix cont-init smoke flake)

### DIFF
--- a/apps/steam/build-fedora/Dockerfile
+++ b/apps/steam/build-fedora/Dockerfile
@@ -45,6 +45,18 @@ _INSTALL_STEAM
 # create symlink for improved decky loader compatibility
 RUN ln -sf "$HOME" /home/deck
 
+# Bake Decky Loader at build time. Previously system-services.sh fetched
+# the latest release on every container start via api.github.com, which
+# rate-limited (60 unauth req/h per IP) and broke cont-init smoke tests
+# and fresh-user logins non-deterministically. Pinning + baking removes
+# the runtime API dependency. Bump DECKY_LOADER_VERSION to update.
+ARG DECKY_LOADER_VERSION=v3.2.3
+RUN mkdir -p /opt/decky && \
+    curl -fsSL --retry 3 --retry-delay 2 \
+      -o /opt/decky/PluginLoader \
+      "https://github.com/SteamDeckHomebrew/decky-loader/releases/download/${DECKY_LOADER_VERSION}/PluginLoader" && \
+    chmod 755 /opt/decky/PluginLoader
+
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh
 COPY --chmod=777 steamos-update /usr/bin/steamos-update

--- a/apps/steam/build-fedora/scripts/system-services.sh
+++ b/apps/steam/build-fedora/scripts/system-services.sh
@@ -50,16 +50,19 @@ if [ -d "$STEAMDIR_LEGACY" ] && [ ! -L "$STEAMDIR_LEGACY" ]; then
   exit 1
 fi
 
-# Install Decky Loader
+# Install Decky Loader. The PluginLoader binary is baked into the image
+# at /opt/decky/PluginLoader during build (see Dockerfile), so this
+# first-run install is offline and deterministic — the cont-init smoke
+# test no longer depends on the GitHub releases API rate limit, and
+# fresh user containers do not roll the rate-limit dice on every start.
 if [ ! -f "$HOME/homebrew/services/PluginLoader" ]; then
   gow_log "Installing Decky Loader"
   mkdir -p "$STEAMDIR"
   touch "$STEAMDIR/.cef-enable-remote-debugging"
   echo "Steam directory: $STEAMDIR"
   mkdir -p "$HOME/homebrew/services/"
-  github_download "SteamDeckHomebrew/decky-loader" ".assets[]|select(.name|(\"PluginLoader\")).browser_download_url" "PluginLoader"
-  chmod +x PluginLoader
-  mv PluginLoader "$HOME/homebrew/services"
+  cp /opt/decky/PluginLoader "$HOME/homebrew/services/PluginLoader"
+  chmod +x "$HOME/homebrew/services/PluginLoader"
 fi
 
 # Start Decky Loader

--- a/apps/steam/build/Dockerfile
+++ b/apps/steam/build/Dockerfile
@@ -65,6 +65,18 @@ RUN fc-cache -f -v
 # create symlink for improved decky loader compatibility
 RUN ln -sf "$HOME" /home/deck
 
+# Bake Decky Loader at build time. Previously system-services.sh fetched
+# the latest release on every container start via api.github.com, which
+# rate-limited (60 unauth req/h per IP) and broke cont-init smoke tests
+# and fresh-user logins non-deterministically. Pinning + baking removes
+# the runtime API dependency. Bump DECKY_LOADER_VERSION to update.
+ARG DECKY_LOADER_VERSION=v3.2.3
+RUN mkdir -p /opt/decky && \
+    curl -fsSL --retry 3 --retry-delay 2 \
+      -o /opt/decky/PluginLoader \
+      "https://github.com/SteamDeckHomebrew/decky-loader/releases/download/${DECKY_LOADER_VERSION}/PluginLoader" && \
+    chmod 755 /opt/decky/PluginLoader
+
 COPY --chmod=777 scripts/startup.sh /opt/gow/startup-app.sh
 COPY --chmod=777 scripts/system-services.sh /etc/cont-init.d/system-services.sh
 COPY --chmod=777 steamos-update /usr/bin/steamos-update

--- a/apps/steam/build/scripts/system-services.sh
+++ b/apps/steam/build/scripts/system-services.sh
@@ -15,16 +15,19 @@ gow_log "*** NetworkManager started ***"
 steamos-dbus-watchdog.sh &
 gow_log "*** D-Bus Watchdog started ***"
 
-# Install Decky Loader
+# Install Decky Loader. The PluginLoader binary is baked into the image
+# at /opt/decky/PluginLoader during build (see Dockerfile), so this
+# first-run install is offline and deterministic — the cont-init smoke
+# test no longer depends on the GitHub releases API rate limit, and
+# fresh user containers do not roll the rate-limit dice on every start.
 if [ ! -f "$HOME/homebrew/services/PluginLoader" ]; then
   gow_log "Installing Decky Loader"
   mkdir -p "$HOME/.steam/steam/"
   mkdir -p "$HOME/.steam/debian-installation/"
   touch "$HOME/.steam/debian-installation/.cef-enable-remote-debugging"
   mkdir -p "$HOME/homebrew/services/"
-  github_download "SteamDeckHomebrew/decky-loader" ".assets[]|select(.name|(\"PluginLoader\")).browser_download_url" "PluginLoader"
-  chmod +x PluginLoader
-  mv PluginLoader "$HOME/homebrew/services"
+  cp /opt/decky/PluginLoader "$HOME/homebrew/services/PluginLoader"
+  chmod +x "$HOME/homebrew/services/PluginLoader"
 fi
 
 # Start Decky Loader


### PR DESCRIPTION
## Summary
The cont-init script `apps/steam/build*/scripts/system-services.sh` fetches the latest `decky-loader` PluginLoader release on every container start via `api.github.com`. Unauthenticated GitHub API requests are rate-limited to 60/h per IP, so when a CI runner or a user's egress IP has been recently hammered the call returns a JSON error object. The current pipeline (`curl | jq | xargs wget`) handles that as: jq logs `Cannot iterate over null`, wget runs with no URL, the next `chmod +x PluginLoader` fails, and the cont-init script exits non-zero. Two visible consequences:

- The Layer 2 cont-init smoke test added in #321 flakes whenever the rate limit is hit (see the failing job on PR #327: https://github.com/games-on-whales/gow/actions/runs/25166479433/job/73774418843). That is not the test being wrong — it correctly catches that cont-init did not exit clean. The flake is the SUT.
- Real users hit the same dice roll on every fresh-profile launch.

This PR removes the runtime API dependency entirely:

- Pin `DECKY_LOADER_VERSION=v3.2.3` and `curl --retry 3` the PluginLoader once during image build, into `/opt/decky/PluginLoader`.
- Replace the runtime `github_download` call with a `cp /opt/decky/PluginLoader` -> `~/homebrew/services/PluginLoader`. No jq, no wget, no API.
- Bump the ARG to take a newer Decky release. Build still hits the GitHub download CDN (not the API endpoint), which is far more lenient.

Applied to both Ubuntu and Fedora Steam images.

## Test plan
- [ ] Build both images locally; confirm `/opt/decky/PluginLoader` exists and is executable.
- [ ] Run `bin/test-image.sh steam <tag> --docker-path apps` (Ubuntu) and the Fedora variant; Layer 2 cont-init smoke passes deterministically with no network.
- [ ] Fresh user profile: `~/homebrew/services/PluginLoader` is copied from `/opt/decky/`; Decky Loader starts.
- [ ] Existing user profile (PluginLoader already present): copy is skipped, behavior unchanged.
