### PR TITLE
Add libopengl0 to prismlauncher image

### DIFF
--- a/apps/prismlauncher/build/Dockerfile
+++ b/apps/prismlauncher/build/Dockerfile
@@ -8,6 +8,7 @@ ARG REQUIRED_PACKAGES=" \
     openjdk-21-jre \
     openjdk-17-jre \
     openjdk-8-jre \
+    libopengl0 \
     "
 
 RUN apt-get update && \


### PR DESCRIPTION
I was trying to play the modpack  https://www.curseforge.com/minecraft/modpacks/homestead-cozy, but game crashed at launch with the following error (full log at https://pastebin.com/bPjFqXNr):
```txt
Caused by: java.lang.UnsatisfiedLinkError: /home/********/.local/share/PrismLauncher/instances/Homestead/minecraft/libEffekseerNativeForJava.so: libOpenGL.so.0: cannot open shared object file: No such file or directory
```
I have added libopengl0 to the prismlauncher image and now the modpack launches.