### PR TITLE
base: fix misleading log message in 30-nvidia.sh for container toolkit path

### DIFF
--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -58,7 +58,16 @@ jobs:
 
       - id: set-docker-vars
         run: |
-          if [[ "${{ github.repository }}" == "games-on-whales/gow" ]]; then
+          # github.repository is always the base repo (games-on-whales/gow) even
+          # for fork PRs, so we can't use it to detect forks. Instead compare
+          # the PR head repo against the base repo.
+          IS_FORK_PR=false
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && \
+             [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            IS_FORK_PR=true
+          fi
+
+          if [[ "${IS_FORK_PR}" == "false" ]]; then
             IS_FORK=false
             GHCR_NAMESPACE="${{ github.repository_owner }}"
             DOCKERHUB_NAMESPACE="${{ env.DOCKERHUB_NAMESPACE }}"
@@ -66,16 +75,10 @@ jobs:
           else
             # Forks shall push to <username>/gow/<image-name>
             IS_FORK=true
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              # For PRs, we use the forked repository owner as namespace
-              # This allows us to pull build caches from the forked repository
-              owner=$(echo ${{ github.event.pull_request.head.repo.owner.login }} | tr '[:upper:]' '[:lower:]')
-              GHCR_NAMESPACE="${owner}/gow"
-            else
-              # For branches, we use the repository owner as namespace
-              owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-              GHCR_NAMESPACE="${owner}/gow"
-            fi
+            # For PRs, we use the forked repository owner as namespace
+            # This allows us to pull build caches from the forked repository
+            owner=$(echo ${{ github.event.pull_request.head.repo.owner.login }} | tr '[:upper:]' '[:lower:]')
+            GHCR_NAMESPACE="${owner}/gow"
             DOCKERHUB_NAMESPACE="${{ env.DOCKERHUB_NAMESPACE }}"
             ARM64_RUNNER=${{ env.ARM64_RUNNER != '' && env.ARM64_RUNNER || 'ubuntu-latest' }}
           fi

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -255,25 +255,30 @@ jobs:
           echo "==> Buildx outputs: ${BUILDX_OUTPUT}"
           echo "==> GitHub server URL: ${GITHUB_SERVER_URL}"
 
+      # Artifact name must match the upload step's name in the producing job,
+      # which appends the variant suffix (see "Upload docker image as artifact"
+      # below). The consuming job inherits the same `inputs.variant` from
+      # auto-build.yml's chain (e.g. base-app-fedora -> base-fedora), so the
+      # suffix here mirrors that of the upstream upload.
       - name: Download base image artifact
         id: download-base-image-artifact
         if: ${{ needs.prepare.outputs.is_fork == 'true' && steps.prep.outputs.base_image_name != '' }}
         uses: dawidd6/action-download-artifact@v10
         with:
-          name: docker-${{ steps.prep.outputs.base_image_name }}-${{ env.PLATFORM_PAIR }}.tar
+          name: docker-${{ steps.prep.outputs.base_image_name }}${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}-${{ env.PLATFORM_PAIR }}.tar
           workflow_search: true
           search_artifacts: true
           allow_forks: true
           workflow_conclusion: ""
           commit: ${{ github.event.pull_request.head.sha }}
           path: /tmp/
-      
+
       - name: Download base-app image artifact
         id: download-base-app-image-artifact
         if: ${{ needs.prepare.outputs.is_fork == 'true' && steps.prep.outputs.base_app_image_name != '' }}
         uses: dawidd6/action-download-artifact@v10
         with:
-          name: docker-${{ steps.prep.outputs.base_app_image_name }}-${{ env.PLATFORM_PAIR }}.tar
+          name: docker-${{ steps.prep.outputs.base_app_image_name }}${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}-${{ env.PLATFORM_PAIR }}.tar
           workflow_search: true
           search_artifacts: true
           allow_forks: true

--- a/images/base/build-fedora/overlay/etc/cont-init.d/30-nvidia.sh
+++ b/images/base/build-fedora/overlay/etc/cont-init.d/30-nvidia.sh
@@ -37,7 +37,7 @@ if [ -d /usr/nvidia ]; then
   fi
 # Check if there's libnvidia-allocator.so.1
 elif [ -e /usr/lib64/libnvidia-allocator.so.1 ]; then
-  gow_log "Nvidia driver detected, assuming it's using the nvidia driver volume"
+  gow_log "Nvidia driver detected, assuming nvidia container toolkit is installed"
   ldconfig
 
   # Create a symlink to the nvidia-drm_gbm.so (if not present)
@@ -91,5 +91,19 @@ elif [ -e /usr/lib64/libnvidia-allocator.so.1 ]; then
         "library_path": "libnvidia-egl-wayland.so.1"
       }
     }' > /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
+  fi
+
+  # gst-cuda loads "libnvrtc.so" via ldconfig. The image ships libnvrtc.so.11.0
+  # (CUDA 11.0) as a fallback, but nvrtcGetCUBIN* were added in CUDA 11.1.
+  # If the toolkit has injected a newer libnvrtc from the host at a standard
+  # system path, symlink it over the baked-in version so ldconfig finds it first.
+  _host_nvrtc=$(ldconfig -p 2>/dev/null \
+    | awk '/libnvrtc\.so[^.0-9]/{print $NF}' \
+    | grep -v '/usr/local/nvidia/lib' \
+    | head -1)
+  if [ -n "$_host_nvrtc" ]; then
+    gow_log "Preferring host nvrtc over baked-in: $_host_nvrtc"
+    ln -sf "$_host_nvrtc" /usr/local/nvidia/lib/libnvrtc.so
+    ldconfig
   fi
 fi

--- a/images/base/build/overlay/etc/cont-init.d/30-nvidia.sh
+++ b/images/base/build/overlay/etc/cont-init.d/30-nvidia.sh
@@ -37,7 +37,7 @@ if [ -d /usr/nvidia ]; then
   fi
 # Check if there's libnvidia-allocator.so.1
 elif [ -e /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1 ]; then
-  gow_log "Nvidia driver detected, assuming it's using the nvidia driver volume"
+  gow_log "Nvidia driver detected, assuming nvidia container toolkit is installed"
   ldconfig
 
   # Create a symlink to the nvidia-drm_gbm.so (if not present)
@@ -91,5 +91,19 @@ elif [ -e /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1 ]; then
         "library_path": "libnvidia-egl-wayland.so.1"
       }
     }' > /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
+  fi
+
+  # gst-cuda loads "libnvrtc.so" via ldconfig. The image ships libnvrtc.so.11.0
+  # (CUDA 11.0) as a fallback, but nvrtcGetCUBIN* were added in CUDA 11.1.
+  # If the toolkit has injected a newer libnvrtc from the host at a standard
+  # system path, symlink it over the baked-in version so ldconfig finds it first.
+  _host_nvrtc=$(ldconfig -p 2>/dev/null \
+    | awk '/libnvrtc\.so[^.0-9]/{print $NF}' \
+    | grep -v '/usr/local/nvidia/lib' \
+    | head -1)
+  if [ -n "$_host_nvrtc" ]; then
+    gow_log "Preferring host nvrtc over baked-in: $_host_nvrtc"
+    ln -sf "$_host_nvrtc" /usr/local/nvidia/lib/libnvrtc.so
+    ldconfig
   fi
 fi


### PR DESCRIPTION
## Summary

- Fix misleading log message: the container toolkit detection branch was logging `"assuming it's using the nvidia driver volume"` — the opposite of what's happening
- In the same toolkit path, prefer any host-injected `libnvrtc.so` (registered in ldconfig outside `/usr/local/nvidia/lib`) over the baked-in CUDA 11.0 version
- Fix fork PR CI: `github.repository` is always the base repo name even for fork PRs, so fork detection was always false and all PRs tried to push to `ghcr.io/games-on-whales`, failing with `denied` for external contributors

## Changes

### `images/base/build*/overlay/etc/cont-init.d/30-nvidia.sh`

Fix log message on the toolkit path (`libnvidia-allocator.so.1` present, no `/usr/nvidia` volume).

After `ldconfig` runs, check if a `libnvrtc.so` is registered in the system cache from outside `/usr/local/nvidia/lib` — i.e. injected by the toolkit from the host's CUDA installation. If found, symlink it over the baked-in CUDA 11.0 version so `gst-cuda` picks up the newer one automatically.

Background: `gst-cuda` loads `libnvrtc.so` via `ldconfig` and treats `nvrtcGetCUBIN*` as optional — without them CUBIN is disabled but PTX still works and nvcodec encoding is unaffected. The image ships `libnvrtc.so.11.0` (CUDA 11.0) as a fallback; `nvrtcGetCUBINSize`/`nvrtcGetCUBIN` were added in CUDA 11.1. On hosts with a full CUDA toolkit, the toolkit injects the host's `libnvrtc` at a standard system path — this change makes that version win over the baked-in 11.0.

### `.github/workflows/docker-build-and-publish.yml`

Fix fork PR detection. `github.repository` is always the base repo (`games-on-whales/gow`) even when the PR comes from a fork, so the previous `if github.repository == games-on-whales/gow` check was always true — `is_fork` was never set, and the build always tried to push to `ghcr.io/games-on-whales`. For fork contributors whose `GITHUB_TOKEN` is read-only, this produced `denied: installation not allowed to Write organization package`.

Fix: compare `github.event.pull_request.head.repo.full_name` against `github.repository` on `pull_request` events. Push-to-master behaviour is unchanged.

Note: this fix takes effect once merged to master — it cannot retroactively fix CI on the current PR run since fork PRs execute the workflow from the base repo.

## Test plan

- [ ] Fork PR CI: build succeeds, image saved as artifact instead of pushed to registry
- [ ] Non-fork PR / master push: no change in behaviour, still pushes to `ghcr.io/games-on-whales`
- [ ] Container with toolkit + host CUDA 11.1+: logs `Preferring host nvrtc`, gst-cuda gets `have_cubin = TRUE`
- [ ] Container with toolkit + no host CUDA: baked-in 11.0 used, no regression
- [ ] Container with driver volume (`/usr/nvidia`): no change in behaviour