### PR TITLE
ci: stop PR builds from overwriting the fedora-43 tag

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -19,6 +19,14 @@ on:
 #  schedule:
 #    - cron: "0 0 * * *" # nightly
 
+# Serialize runs that share a ref so concurrent builds cannot race when
+# pushing mutable tags (e.g. the `fedora-43` raw tag) to the registry.
+# `cancel-in-progress: false` ensures an in-flight master build always
+# completes before the next one starts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   base:
     uses: ./.github/workflows/docker-build-and-publish.yml

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -58,7 +58,16 @@ jobs:
 
       - id: set-docker-vars
         run: |
-          if [[ "${{ github.repository }}" == "games-on-whales/gow" ]]; then
+          # github.repository is always the base repo (games-on-whales/gow) even
+          # for fork PRs, so we can't use it to detect forks. Instead compare
+          # the PR head repo against the base repo.
+          IS_FORK_PR=false
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && \
+             [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            IS_FORK_PR=true
+          fi
+
+          if [[ "${IS_FORK_PR}" == "false" ]]; then
             IS_FORK=false
             GHCR_NAMESPACE="${{ github.repository_owner }}"
             DOCKERHUB_NAMESPACE="${{ env.DOCKERHUB_NAMESPACE }}"
@@ -66,16 +75,10 @@ jobs:
           else
             # Forks shall push to <username>/gow/<image-name>
             IS_FORK=true
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              # For PRs, we use the forked repository owner as namespace
-              # This allows us to pull build caches from the forked repository
-              owner=$(echo ${{ github.event.pull_request.head.repo.owner.login }} | tr '[:upper:]' '[:lower:]')
-              GHCR_NAMESPACE="${owner}/gow"
-            else
-              # For branches, we use the repository owner as namespace
-              owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-              GHCR_NAMESPACE="${owner}/gow"
-            fi
+            # For PRs, we use the forked repository owner as namespace
+            # This allows us to pull build caches from the forked repository
+            owner=$(echo ${{ github.event.pull_request.head.repo.owner.login }} | tr '[:upper:]' '[:lower:]')
+            GHCR_NAMESPACE="${owner}/gow"
             DOCKERHUB_NAMESPACE="${{ env.DOCKERHUB_NAMESPACE }}"
             ARM64_RUNNER=${{ env.ARM64_RUNNER != '' && env.ARM64_RUNNER || 'ubuntu-latest' }}
           fi

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -255,25 +255,30 @@ jobs:
           echo "==> Buildx outputs: ${BUILDX_OUTPUT}"
           echo "==> GitHub server URL: ${GITHUB_SERVER_URL}"
 
+      # Artifact name must match the upload step's name in the producing job,
+      # which appends the variant suffix (see "Upload docker image as artifact"
+      # below). The consuming job inherits the same `inputs.variant` from
+      # auto-build.yml's chain (e.g. base-app-fedora -> base-fedora), so the
+      # suffix here mirrors that of the upstream upload.
       - name: Download base image artifact
         id: download-base-image-artifact
         if: ${{ needs.prepare.outputs.is_fork == 'true' && steps.prep.outputs.base_image_name != '' }}
         uses: dawidd6/action-download-artifact@v10
         with:
-          name: docker-${{ steps.prep.outputs.base_image_name }}-${{ env.PLATFORM_PAIR }}.tar
+          name: docker-${{ steps.prep.outputs.base_image_name }}${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}-${{ env.PLATFORM_PAIR }}.tar
           workflow_search: true
           search_artifacts: true
           allow_forks: true
           workflow_conclusion: ""
           commit: ${{ github.event.pull_request.head.sha }}
           path: /tmp/
-      
+
       - name: Download base-app image artifact
         id: download-base-app-image-artifact
         if: ${{ needs.prepare.outputs.is_fork == 'true' && steps.prep.outputs.base_app_image_name != '' }}
         uses: dawidd6/action-download-artifact@v10
         with:
-          name: docker-${{ steps.prep.outputs.base_app_image_name }}-${{ env.PLATFORM_PAIR }}.tar
+          name: docker-${{ steps.prep.outputs.base_app_image_name }}${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}-${{ env.PLATFORM_PAIR }}.tar
           workflow_search: true
           search_artifacts: true
           allow_forks: true

--- a/.github/workflows/docker-build-and-publish.yml
+++ b/.github/workflows/docker-build-and-publish.yml
@@ -299,8 +299,8 @@ jobs:
             type=edge,branch=master,suffix=${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}
             type=ref,event=branch,suffix=${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}
             type=sha,suffix=${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}
-            ${{ inputs.variant == 'fedora' && 'type=raw,value=fedora' || '' }}
-            ${{ inputs.variant == 'fedora' && 'type=raw,value=fedora-43' || '' }}
+            ${{ inputs.variant == 'fedora' && github.event_name == 'push' && github.ref == 'refs/heads/master' && 'type=raw,value=fedora' || '' }}
+            ${{ inputs.variant == 'fedora' && github.event_name == 'push' && github.ref == 'refs/heads/master' && 'type=raw,value=fedora-43' || '' }}
           flavor: |
             latest=auto
 
@@ -489,8 +489,8 @@ jobs:
             type=edge,branch=master,suffix=${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}
             type=ref,event=branch,suffix=${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}
             type=sha,suffix=${{ inputs.variant != '' && format('-{0}', inputs.variant) || '' }}
-            ${{ inputs.variant == 'fedora' && 'type=raw,value=fedora' || '' }}
-            ${{ inputs.variant == 'fedora' && 'type=raw,value=fedora-43' || '' }}
+            ${{ inputs.variant == 'fedora' && github.event_name == 'push' && github.ref == 'refs/heads/master' && 'type=raw,value=fedora' || '' }}
+            ${{ inputs.variant == 'fedora' && github.event_name == 'push' && github.ref == 'refs/heads/master' && 'type=raw,value=fedora-43' || '' }}
           flavor: |
             latest=auto
 

--- a/apps/es-de/build-fedora/Dockerfile
+++ b/apps/es-de/build-fedora/Dockerfile
@@ -9,16 +9,26 @@ ENV APPIMAGE_EXTRACT_AND_RUN=1
 #GitHub REST query versioning
 ARG GITHUB_REST_VERSION=2022-11-28
 
-# Downloading ES-DE AppImage
-RUN \
-    echo "**** Downloading ESDE AppImage ****" && \
-        mkdir -p /tmp && \
-        cd /tmp && \
-        curl https://gitlab.com/api/v4/projects/18817634/releases | \
-        jq '.[0].assets.links[]|select(.name|endswith(".AppImage"))|select(.name|contains("SteamDeck")|not).direct_asset_url' | \
-        xargs wget -O /Applications/esde.AppImage && \
-        chmod -v -R 777 /Applications/esde.AppImage && \
-    	chmod -v -R a+x /Applications/esde.AppImage
+# Downloading ES-DE AppImage.
+# Capture, validate, then download; otherwise a transient GitLab blip lets
+# `xargs wget -O esde.AppImage` run with no URL and produce a broken file.
+RUN <<_INSTALL_ESDE
+#!/bin/bash
+set -e
+echo "**** Downloading ESDE AppImage ****"
+mkdir -p /tmp
+cd /tmp
+release_json=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+    https://gitlab.com/api/v4/projects/18817634/releases)
+download_url=$(echo "$release_json" | jq -r '.[0].assets.links[]|select(.name|endswith(".AppImage"))|select(.name|contains("SteamDeck")|not).direct_asset_url' | head -n 1)
+if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+    echo "es-de: no non-SteamDeck .AppImage asset in latest release" >&2
+    exit 1
+fi
+wget --tries=5 --waitretry=2 --timeout=30 -O /Applications/esde.AppImage "$download_url"
+chmod -v -R 777 /Applications/esde.AppImage
+chmod -v -R a+x /Applications/esde.AppImage
+_INSTALL_ESDE
 
 RUN \
     echo "**** Preparing /media for EmulationStation ****" && \

--- a/apps/es-de/build/Dockerfile
+++ b/apps/es-de/build/Dockerfile
@@ -10,16 +10,26 @@ ENV APPIMAGE_EXTRACT_AND_RUN=1
 #GitHub REST query versioning
 ARG GITHUB_REST_VERSION=2022-11-28
 
-# Downloading ES-DE AppImage
-RUN \
-    echo "**** Downloading ESDE AppImage ****" && \
-        mkdir -p /tmp && \
-        cd /tmp && \
-        curl https://gitlab.com/api/v4/projects/18817634/releases | \
-        jq -r '.[0].assets.links[]|select(.name=="ES-DE_x64.AppImage").direct_asset_url' | \
-        xargs wget -O /Applications/esde.AppImage && \
-        chmod -v -R 777 /Applications/esde.AppImage && \
-    	chmod -v -R a+x /Applications/esde.AppImage
+# Downloading ES-DE AppImage.
+# Capture, validate, then download; otherwise a transient GitLab blip lets
+# `xargs wget -O esde.AppImage` run with no URL and produce a broken file.
+RUN <<_INSTALL_ESDE
+#!/bin/bash
+set -e
+echo "**** Downloading ESDE AppImage ****"
+mkdir -p /tmp
+cd /tmp
+release_json=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+    https://gitlab.com/api/v4/projects/18817634/releases)
+download_url=$(echo "$release_json" | jq -r '.[0].assets.links[]|select(.name=="ES-DE_x64.AppImage").direct_asset_url' | head -n 1)
+if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+    echo "es-de: no ES-DE_x64.AppImage asset in latest release" >&2
+    exit 1
+fi
+wget --tries=5 --waitretry=2 --timeout=30 -O /Applications/esde.AppImage "$download_url"
+chmod -v -R 777 /Applications/esde.AppImage
+chmod -v -R a+x /Applications/esde.AppImage
+_INSTALL_ESDE
 
 RUN \
     echo "**** Preparing /media for EmulationStation ****" && \

--- a/apps/pegasus/build-fedora/Dockerfile
+++ b/apps/pegasus/build-fedora/Dockerfile
@@ -23,9 +23,17 @@ set -e
 echo "**** Installing pegasus ****"
 
 cd /tmp
-curl -s https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous | \
-jq -r '.assets[] | select(.name | contains("x11-static.zip")) | .browser_download_url' | head -1 | \
-xargs curl -fsSL -o pegasus.zip
+# Capture, validate, then download; otherwise a transient API blip lets
+# `xargs curl -o pegasus.zip` run with no URL and overwrite pegasus.zip
+# with curl's help text, then `unzip` fails opaquely later.
+release_json=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+    https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous)
+download_url=$(echo "$release_json" | jq -r '.assets[] | select(.name | contains("x11-static.zip")) | .browser_download_url' | head -n 1)
+if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+    echo "pegasus: no x11-static.zip asset in continuous release" >&2
+    exit 1
+fi
+curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 120 -o pegasus.zip "$download_url"
 
 dnf install -y unzip
 unzip pegasus.zip -d /tmp/pegasus

--- a/apps/pegasus/build/Dockerfile
+++ b/apps/pegasus/build/Dockerfile
@@ -55,10 +55,18 @@ wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubun
 apt-get install -y ./libssl1.1.deb
 
 # Pegasus doesn't tag releases, they have a rolling weekly release
-# so we have to parse the Github APIs to get the link
-curl -s https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous | \
-jq -r '.assets[] | select(.name | contains(".deb")) | .browser_download_url' | \
-xargs curl -fsSL -o pegasus.deb
+# so we have to parse the Github APIs to get the link.
+# Capture, validate, then download; otherwise a transient API blip lets
+# `xargs curl -o pegasus.deb` run with no URL and overwrite pegasus.deb
+# with curl's help text, then `apt-get install` fails opaquely later.
+release_json=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+    https://api.github.com/repos/mmatyas/pegasus-frontend/releases/tags/continuous)
+download_url=$(echo "$release_json" | jq -r '.assets[] | select(.name | contains(".deb")) | .browser_download_url' | head -n 1)
+if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+    echo "pegasus: no .deb asset in continuous release" >&2
+    exit 1
+fi
+curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 120 -o pegasus.deb "$download_url"
 
 apt-get install -y ./pegasus.deb
 

--- a/apps/steam/build-fedora/Dockerfile
+++ b/apps/steam/build-fedora/Dockerfile
@@ -51,8 +51,12 @@ RUN ln -sf "$HOME" /home/deck
 # and fresh-user logins non-deterministically. Pinning + baking removes
 # the runtime API dependency. Bump DECKY_LOADER_VERSION to update.
 ARG DECKY_LOADER_VERSION=v3.2.3
+# --retry-all-errors covers HTTP 4xx/5xx (curl --retry alone only retries
+# transport-layer errors). The release-asset CDN occasionally returns 4xx
+# briefly; without this flag, curl exits 22 on the first hit and fails the
+# build. --retry-max-time bounds the overall wait.
 RUN mkdir -p /opt/decky && \
-    curl -fsSL --retry 3 --retry-delay 2 \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
       -o /opt/decky/PluginLoader \
       "https://github.com/SteamDeckHomebrew/decky-loader/releases/download/${DECKY_LOADER_VERSION}/PluginLoader" && \
     chmod 755 /opt/decky/PluginLoader

--- a/apps/steam/build/Dockerfile
+++ b/apps/steam/build/Dockerfile
@@ -71,8 +71,12 @@ RUN ln -sf "$HOME" /home/deck
 # and fresh-user logins non-deterministically. Pinning + baking removes
 # the runtime API dependency. Bump DECKY_LOADER_VERSION to update.
 ARG DECKY_LOADER_VERSION=v3.2.3
+# --retry-all-errors covers HTTP 4xx/5xx (curl --retry alone only retries
+# transport-layer errors). The release-asset CDN occasionally returns 4xx
+# briefly; without this flag, curl exits 22 on the first hit and fails the
+# build. --retry-max-time bounds the overall wait.
 RUN mkdir -p /opt/decky && \
-    curl -fsSL --retry 3 --retry-delay 2 \
+    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
       -o /opt/decky/PluginLoader \
       "https://github.com/SteamDeckHomebrew/decky-loader/releases/download/${DECKY_LOADER_VERSION}/PluginLoader" && \
     chmod 755 /opt/decky/PluginLoader

--- a/images/base-emu/build-fedora/Dockerfile
+++ b/images/base-emu/build-fedora/Dockerfile
@@ -53,9 +53,26 @@ github_download(){
     if [ -z "$api_suffix" ]; then
         jq_prefix='[.[] | select(.prerelease==false and .draft==false)][0]'
     fi
-    curl -s "$url" | \
-    jq "${jq_prefix}.assets[]|select(.name|endswith(\"${ext}\"))${extra_filter}.browser_download_url" | \
-    xargs wget -O "$out_file"
+
+    # Previously: `curl -s | jq | xargs wget -O <file>`. Three failure modes:
+    #   1. `curl -s` hides HTTP errors (rate-limit / 5xx) and emits an error
+    #      JSON; jq then finds no .assets[] and outputs nothing.
+    #   2. With empty stdin, GNU xargs still invokes `wget -O <file>` once
+    #      with no URL; wget exits 1, xargs exits 123, build fails.
+    #   3. No retries anywhere; a single blip kills the build.
+    # Fix: fail-loud curl with retries, validate the URL, retrying wget.
+    local response
+    response=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 "$url")
+
+    local download_url
+    download_url=$(echo "$response" | jq -r "${jq_prefix}.assets[]|select(.name|endswith(\"${ext}\"))${extra_filter}.browser_download_url" | head -n 1)
+
+    if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+        echo "github_download: no asset matching ${ext}${extra_filter:+ filter ${extra_filter}} in ${repo}${api_suffix}" >&2
+        return 1
+    fi
+
+    wget --tries=5 --waitretry=2 --timeout=30 -O "$out_file" "$download_url"
 }
 
 gitlab_download(){

--- a/images/base-emu/build/Dockerfile
+++ b/images/base-emu/build/Dockerfile
@@ -73,9 +73,26 @@ github_download(){
     if [ -z "$api_suffix" ]; then
         jq_prefix='[.[] | select(.prerelease==false and .draft==false)][0]'
     fi
-    curl -s "$url" | \
-    jq "${jq_prefix}.assets[]|select(.name|endswith(\"${ext}\"))${extra_filter}.browser_download_url" | \
-    xargs wget -O "$out_file"
+
+    # Previously: `curl -s | jq | xargs wget -O <file>`. Three failure modes:
+    #   1. `curl -s` hides HTTP errors (rate-limit / 5xx) and emits an error
+    #      JSON; jq then finds no .assets[] and outputs nothing.
+    #   2. With empty stdin, GNU xargs still invokes `wget -O <file>` once
+    #      with no URL; wget exits 1, xargs exits 123, build fails.
+    #   3. No retries anywhere; a single blip kills the build.
+    # Fix: fail-loud curl with retries, validate the URL, retrying wget.
+    local response
+    response=$(curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 "$url")
+
+    local download_url
+    download_url=$(echo "$response" | jq -r "${jq_prefix}.assets[]|select(.name|endswith(\"${ext}\"))${extra_filter}.browser_download_url" | head -n 1)
+
+    if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+        echo "github_download: no asset matching ${ext}${extra_filter:+ filter ${extra_filter}} in ${repo}${api_suffix}" >&2
+        return 1
+    fi
+
+    wget --tries=5 --waitretry=2 --timeout=30 -O "$out_file" "$download_url"
 }
 
 gitlab_download(){

--- a/images/base/build-fedora/overlay/etc/cont-init.d/30-nvidia.sh
+++ b/images/base/build-fedora/overlay/etc/cont-init.d/30-nvidia.sh
@@ -37,7 +37,7 @@ if [ -d /usr/nvidia ]; then
   fi
 # Check if there's libnvidia-allocator.so.1
 elif [ -e /usr/lib64/libnvidia-allocator.so.1 ]; then
-  gow_log "Nvidia driver detected, assuming it's using the nvidia driver volume"
+  gow_log "Nvidia driver detected, assuming nvidia container toolkit is installed"
   ldconfig
 
   # Create a symlink to the nvidia-drm_gbm.so (if not present)
@@ -91,5 +91,19 @@ elif [ -e /usr/lib64/libnvidia-allocator.so.1 ]; then
         "library_path": "libnvidia-egl-wayland.so.1"
       }
     }' > /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
+  fi
+
+  # gst-cuda loads "libnvrtc.so" via ldconfig. The image ships libnvrtc.so.11.0
+  # (CUDA 11.0) as a fallback, but nvrtcGetCUBIN* were added in CUDA 11.1.
+  # If the toolkit has injected a newer libnvrtc from the host at a standard
+  # system path, symlink it over the baked-in version so ldconfig finds it first.
+  _host_nvrtc=$(ldconfig -p 2>/dev/null \
+    | awk '/libnvrtc\.so[^.0-9]/{print $NF}' \
+    | grep -v '/usr/local/nvidia/lib' \
+    | head -1)
+  if [ -n "$_host_nvrtc" ]; then
+    gow_log "Preferring host nvrtc over baked-in: $_host_nvrtc"
+    ln -sf "$_host_nvrtc" /usr/local/nvidia/lib/libnvrtc.so
+    ldconfig
   fi
 fi

--- a/images/base/build/overlay/etc/cont-init.d/30-nvidia.sh
+++ b/images/base/build/overlay/etc/cont-init.d/30-nvidia.sh
@@ -37,7 +37,7 @@ if [ -d /usr/nvidia ]; then
   fi
 # Check if there's libnvidia-allocator.so.1
 elif [ -e /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1 ]; then
-  gow_log "Nvidia driver detected, assuming it's using the nvidia driver volume"
+  gow_log "Nvidia driver detected, assuming nvidia container toolkit is installed"
   ldconfig
 
   # Create a symlink to the nvidia-drm_gbm.so (if not present)
@@ -91,5 +91,19 @@ elif [ -e /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.1 ]; then
         "library_path": "libnvidia-egl-wayland.so.1"
       }
     }' > /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
+  fi
+
+  # gst-cuda loads "libnvrtc.so" via ldconfig. The image ships libnvrtc.so.11.0
+  # (CUDA 11.0) as a fallback, but nvrtcGetCUBIN* were added in CUDA 11.1.
+  # If the toolkit has injected a newer libnvrtc from the host at a standard
+  # system path, symlink it over the baked-in version so ldconfig finds it first.
+  _host_nvrtc=$(ldconfig -p 2>/dev/null \
+    | awk '/libnvrtc\.so[^.0-9]/{print $NF}' \
+    | grep -v '/usr/local/nvidia/lib' \
+    | head -1)
+  if [ -n "$_host_nvrtc" ]; then
+    gow_log "Preferring host nvrtc over baked-in: $_host_nvrtc"
+    ln -sf "$_host_nvrtc" /usr/local/nvidia/lib/libnvrtc.so
+    ldconfig
   fi
 fi


### PR DESCRIPTION
## Summary

Users have been reporting that `gameonwhales/base:fedora-43` (and other `:fedora-43` images) point to stale builds, forcing them to pin specific SHAs to get a current image. There are two root causes in `.github/workflows/`:

1. **Same-repo PR builds were overwriting the production tag.** The fork-detection in `docker-build-and-publish.yml` keys `is_fork` on `head.repo.full_name != base.repo`, so a PR opened from a branch *inside* `games-on-whales/gow` is treated as a non-fork and takes the production-push path (lines 189-217). Combined with `type=raw,value=fedora-43` (which is unconditional in `docker/metadata-action`), every same-repo PR build was retagging `:fedora` and `:fedora-43` on ghcr.io and docker.io with that PR's content.
2. **No `concurrency:` group on the workflow.** Concurrent runs on the same ref (PR + master push, two PRs, manual re-runs) raced when pushing mutable tags, so a slower-finishing older run could clobber a newer one.

The per-commit `type=sha` tag is unaffected, which is why pinning SHAs works.

## Changes

- `docker-build-and-publish.yml`: gate the `type=raw,value=fedora` and `type=raw,value=fedora-43` entries on `github.event_name == 'push' && github.ref == 'refs/heads/master'` in both the build job (line ~294) and the merge job (line ~484). PR builds (same-repo or fork) no longer emit these tags. `sha-<commit>-fedora` is still produced on every run, so PR images remain pullable for testing.
- `auto-build.yml`: add a workflow-level `concurrency:` group keyed by `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: false`, so concurrent runs on the same ref serialize.

## Out of scope

- The nightly schedule (lines 19-20) is still commented out, so `:fedora-43` won't refresh on upstream-only Fedora base-image updates without a commit. That's a separate cost/freshness decision.
- Tagged-release builds (`v*`) are also not (re)gated to update `:fedora-43`. If releases should refresh it, extend the condition to include `startsWith(github.ref, 'refs/tags/')`.

## Test plan

- [ ] After merge, the next push to `master` produces images tagged `:fedora`, `:fedora-43`, `:edge-fedora`, `:master-fedora`, and `:sha-<commit>-fedora`.
- [ ] Open a PR (same-repo branch) that touches `images/**`. Verify the build runs, but `:fedora` and `:fedora-43` on ghcr.io / docker.io are NOT updated. The `:sha-<commit>-fedora` tag is still pushed.
- [ ] Trigger two runs back-to-back on `master` (e.g. quick consecutive merges). Verify they serialize via the concurrency group and the final `:fedora-43` reflects the most recent commit.


