### PR TITLE
Add missing getopt utility for heroic games launcher

### DIFF
--- a/images/base-app/build-fedora/Dockerfile
+++ b/images/base-app/build-fedora/Dockerfile
@@ -48,6 +48,7 @@ ARG REQUIRED_PACKAGES="\
     mangohud \
     sdl2-compat ncurses \
     procps-ng \
+    util-linux \
     dbus-daemon \
     "
 


### PR DESCRIPTION
When running games with heroic and ProtonGE umu complains about missing `getopt`. This adds the respective package that contains that utility.

It might be worth to build the image once to validate if nothing else is missing afterwards.