### PR TITLE
fix(base-emu): ROM-aware launchers, fullscreen, and Xenia path

### DIFF
--- a/images/base-emu/build-fedora/Dockerfile
+++ b/images/base-emu/build-fedora/Dockerfile
@@ -158,12 +158,14 @@ echo "**** Extracting Xenia Canary ****"
 mkdir -p xenia-canary
 tar -xf xenia_canary_linux.tar.xz -C xenia-canary
 rm xenia_canary_linux.tar.xz
+ln -sf build/bin/Linux/Release/xenia_canary xenia-canary/xenia_canary
 
 chmod -v -R 777 $EMULATORS_DIR
 chmod -v -R a+x $EMULATORS_DIR
 _INSTALL_EMULATORS
 
 COPY --chmod=777 launchers /Applications/launchers
+COPY --chmod=755 scripts/rom_platforms.py scripts/generate_rom_library_configs.py scripts/gow_refresh_rom_library.sh scripts/required_cores.py scripts/install_retroarch_cores.sh /opt/gow/rom-config/
 ENV PATH="/Applications/launchers:${PATH}"
 
 RUN \

--- a/images/base-emu/build-fedora/launchers/cemu.sh
+++ b/images/base-emu/build-fedora/launchers/cemu.sh
@@ -2,5 +2,15 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting CEMU with DISPLAY=${DISPLAY}"
-/Applications/cemu-emu.AppImage --appimage-extract-and-run
+APP="/Applications/cemu-emu.AppImage"
+gow_log "Starting Cemu DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -f
+fi
+
+if [[ "${1:-}" == -g && -n "${2:-}" ]]; then
+    exec "$APP" --appimage-extract-and-run -f -g "$2"
+fi
+
+exec "$APP" --appimage-extract-and-run -f "$@"

--- a/images/base-emu/build-fedora/launchers/citron.sh
+++ b/images/base-emu/build-fedora/launchers/citron.sh
@@ -2,5 +2,22 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting Citron with DISPLAY=${DISPLAY}"
-/Applications/citron.AppImage --appimage-extract-and-run "$@"
+APP="/Applications/citron.AppImage"
+gow_log "Starting Citron DISPLAY=${DISPLAY} args: $*"
+
+if [[ ! -f "$APP" ]]; then
+    gow_log "ERROR: Citron AppImage missing at ${APP} (not bundled in current ES-DE image)"
+    exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -f
+fi
+
+for arg in "$@"; do
+    if [[ "$arg" == "-f" || "$arg" == "--fullscreen" ]]; then
+        exec "$APP" --appimage-extract-and-run "$@"
+    fi
+done
+
+exec "$APP" --appimage-extract-and-run -f "$@"

--- a/images/base-emu/build-fedora/launchers/dolphin.sh
+++ b/images/base-emu/build-fedora/launchers/dolphin.sh
@@ -2,5 +2,19 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting dolphin-emu with DISPLAY=${DISPLAY}"
-/Applications/dolphin-emu.AppImage --appimage-extract-and-run
+APP="/Applications/dolphin-emu.AppImage"
+gow_log "Starting dolphin-emu DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run --fullscreen
+fi
+
+if [[ "${1:-}" == --exec && -n "${2:-}" ]]; then
+    exec "$APP" --appimage-extract-and-run --batch --fullscreen --exec="$2"
+fi
+
+if [[ "${1:-}" == --exec=* ]]; then
+    exec "$APP" --appimage-extract-and-run --batch --fullscreen "$1"
+fi
+
+exec "$APP" --appimage-extract-and-run --batch --fullscreen --exec="$1"

--- a/images/base-emu/build-fedora/launchers/pcsx2.sh
+++ b/images/base-emu/build-fedora/launchers/pcsx2.sh
@@ -2,5 +2,11 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting PCSX2-QT with DISPLAY=${DISPLAY}"
-/Applications/pcsx2-emu.AppImage --appimage-extract-and-run
+APP="/Applications/pcsx2-emu.AppImage"
+gow_log "Starting PCSX2 DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -fullscreen
+fi
+
+exec "$APP" --appimage-extract-and-run -fullscreen "$@"

--- a/images/base-emu/build-fedora/launchers/retroarch.sh
+++ b/images/base-emu/build-fedora/launchers/retroarch.sh
@@ -2,5 +2,9 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting RetroArch with DISPLAY=${DISPLAY}"
-retroarch
+gow_log "Starting RetroArch DISPLAY=${DISPLAY} args: $*"
+if [[ $# -eq 0 ]]; then
+    exec retroarch --fullscreen
+fi
+
+exec retroarch --fullscreen "$@"

--- a/images/base-emu/build-fedora/launchers/rom_launcher.sh
+++ b/images/base-emu/build-fedora/launchers/rom_launcher.sh
@@ -2,55 +2,60 @@
 EMULATOR=$1
 ROM=$2
 
-# Mount location where we will mount both zip files and iso files
+# Profile-seeded launchers (repair-esde.sh); fall back to image path.
+GOW_LAUNCHERS="${GOW_LAUNCHERS:-/home/retro/Applications/launchers}"
+if [[ ! -d "$GOW_LAUNCHERS" ]]; then
+    GOW_LAUNCHERS="/Applications/launchers"
+fi
+
 ISO_MOUNT_LOCATION=/media/iso_mount
 
 function launch_ps3 {
+    local ROM_FILE="$1"
 
-  local ROM_FILE="$1"
+    if [[ $ROM_FILE == *.iso ]]; then
+        echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
+        fuseiso "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
+        ROM_FILE=${ISO_MOUNT_LOCATION}
+    fi
 
-  # Mount the folder/file if it's an iso
-  if [[ $ROM_FILE == *.iso ]]; then
-    echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
-    fuseiso "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
-    ROM_FILE=${ISO_MOUNT_LOCATION}
-  fi
+    "${GOW_LAUNCHERS}/rpcs3.sh" "${ROM_FILE}"
 
-  # Launch the game
-  /Applications/rpcs3-emu.AppImage --appimage-extract-and-run  "${ROM_FILE}"
-
-  # Unmount (if we mounted the ISO)
-  if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
-    echo "UnMounting: ${ISO_MOUNT_LOCATION}"
-    fusermount -u ${ISO_MOUNT_LOCATION}
-  fi
+    if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
+        echo "UnMounting: ${ISO_MOUNT_LOCATION}"
+        fusermount -u ${ISO_MOUNT_LOCATION}
+    fi
 }
 
 function launch_scummvm {
+    local ROM_FILE="$1"
 
-  local ROM_FILE="$1"
+    if [[ $ROM_FILE == *.zip ]]; then
+        echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
+        fuse-zip -o ro "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
+        ROM_FILE=${ISO_MOUNT_LOCATION}
+    fi
 
-  # Mount the folder/file if it's an iso
-  if [[ $ROM_FILE == *.zip ]]; then
-    echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
-    fuse-zip -o ro "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
-    ROM_FILE=${ISO_MOUNT_LOCATION}
-  fi
+    SCUMMVM_FILE=`ls ${ISO_MOUNT_LOCATION}/*.scummvm`
 
-  # Find the .scummvm filename
-  SCUMMVM_FILE=`ls ${ISO_MOUNT_LOCATION}/*.scummvm`
+    retroarch --fullscreen -L ~/.config/retroarch/cores/scummvm_libretro.so ${SCUMMVM_FILE}
 
-  # Launch the game
-  retroarch -L ~/.config/retroarch/cores/scummvm_libretro.so ${SCUMMVM_FILE}
-
-  # Unmount (if we mounted the ISO)
-  if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
-    echo "UnMounting: ${ISO_MOUNT_LOCATION}"
-    fusermount -u ${ISO_MOUNT_LOCATION}
-  fi
+    if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
+        echo "UnMounting: ${ISO_MOUNT_LOCATION}"
+        fusermount -u ${ISO_MOUNT_LOCATION}
+    fi
 }
 
-# dictionary of emulator to command to run
+function launch_nes {
+    local ROM_FILE="$1"
+    local CORE_DIR="${HOME}/.config/retroarch/cores"
+    local CORE="fceumm_libretro.so"
+    if [[ ! -f "${CORE_DIR}/${CORE}" && -f "${CORE_DIR}/nestopia_libretro.so" ]]; then
+        CORE="nestopia_libretro.so"
+    fi
+    retroarch --fullscreen -L "${CORE_DIR}/${CORE}" "${ROM_FILE}"
+}
+
 declare -A EMULATOR_COMMAND=( \
 ["3do"]="retroarch --fullscreen -L ~/.config/retroarch/cores/opera_libretro.so \"${ROM}\"" \
 ["arcade"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mame_libretro.so \"${ROM}\"" \
@@ -66,34 +71,35 @@ declare -A EMULATOR_COMMAND=( \
 ["gb"]="retroarch --fullscreen -L ~/.config/retroarch/cores/gambatte_libretro.so \"${ROM}\"" \
 ["gbc"]="retroarch --fullscreen -L ~/.config/retroarch/cores/gambatte_libretro.so \"${ROM}\"" \
 ["gba"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mgba_libretro.so \"${ROM}\"" \
-["gc"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
+["gc"]="${GOW_LAUNCHERS}/dolphin.sh --exec \"${ROM}\"" \
 ["genesis"]="retroarch --fullscreen -L ~/.config/retroarch/cores/picodrive_libretro.so \"${ROM}\"" \
+["mastersystem"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
 ["megacd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
 ["model2"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mame_libretro.so \"${ROM}\"" \
 ["n64"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mupen64plus_next_libretro.so \"${ROM}\"" \
 ["naomi"]="retroarch --fullscreen -L ~/.config/retroarch/cores/flycast_libretro.so \"${ROM}\"" \
 ["neogeo"]="retroarch --fullscreen -L ~/.config/retroarch/cores/fbneo_libretro.so \"${ROM}\"" \
-["nes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/fceumm_libretro.so \"${ROM}\"" \
+["nes"]="launch_nes \"${ROM}\"" \
 ["ngp"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_ngp_libretro.so \"${ROM}\"" \
 ["ngpc"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_ngp_libretro.so \"${ROM}\"" \
 ["psp"]="retroarch --fullscreen -L ~/.config/retroarch/cores/ppsspp_libretro.so \"${ROM}\"" \
 ["psx"]="retroarch --fullscreen -L ~/.config/retroarch/cores/pcsx_rearmed_libretro.so \"${ROM}\"" \
-["ps2"]="/Applications/pcsx2-emu.AppImage --appimage-extract-and-run \"${ROM}\"" \
-["ps3"]="launch_ps3  \"${ROM}\"" \
+["ps2"]="${GOW_LAUNCHERS}/pcsx2.sh \"${ROM}\"" \
+["ps3"]="launch_ps3 \"${ROM}\"" \
 ["saturn"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_saturn_libretro.so \"${ROM}\"" \
 ["sega32x"]="retroarch --fullscreen -L ~/.config/retroarch/cores/picodrive_libretro.so \"${ROM}\"" \
 ["segacd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
 ["scummvm"]="launch_scummvm \"${ROM}\"" \
 ["snes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/snes9x_libretro.so \"${ROM}\"" \
 ["snes_widescreen"]="retroarch --fullscreen -L ~/.config/retroarch/cores/bsnes_hd_beta_libretro.so \"${ROM}\"" \
-["switch"]="/Applications/launchers/citron.sh -f -g \"${ROM}\"" \
+["switch"]="${GOW_LAUNCHERS}/citron.sh -f -g \"${ROM}\"" \
 ["virtualboy"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_vb_libretro.so \"${ROM}\"" \
-["wii"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
-["wiiu"]="/Applications/cemu-emu.AppImage --appimage-extract-and-run -f -g \"${ROM}\"" \
+["wii"]="${GOW_LAUNCHERS}/dolphin.sh --exec \"${ROM}\"" \
+["wiiu"]="${GOW_LAUNCHERS}/cemu.sh -g \"${ROM}\"" \
 ["wonderswan"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_wswan_libretro.so \"${ROM}\"" \
 ["wonderswancolor"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_wswan_libretro.so \"${ROM}\"" \
-["xbox"]="/Applications/xemu-emu.AppImage --appimage-extract-and-run -full-screen -dvd_path \"${ROM}\"" \
-["xbox360"]="/Applications/launchers/xenia.sh --fullscreen \"${ROM}\"" \
+["xbox"]="${GOW_LAUNCHERS}/xemu.sh \"${ROM}\"" \
+["xbox360"]="${GOW_LAUNCHERS}/xenia.sh \"${ROM}\"" \
 )
 
 echo "Running command: ${EMULATOR_COMMAND[${EMULATOR}]}"

--- a/images/base-emu/build-fedora/launchers/rpcs3.sh
+++ b/images/base-emu/build-fedora/launchers/rpcs3.sh
@@ -2,5 +2,11 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting RPCS3 with DISPLAY=${DISPLAY}"
-/Applications/rpcs3-emu.AppImage --appimage-extract-and-run
+APP="/Applications/rpcs3-emu.AppImage"
+gow_log "Starting RPCS3 DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run
+fi
+
+exec "$APP" --appimage-extract-and-run "$@"

--- a/images/base-emu/build-fedora/launchers/xemu.sh
+++ b/images/base-emu/build-fedora/launchers/xemu.sh
@@ -2,5 +2,15 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting XEMU with DISPLAY=${DISPLAY}"
-/Applications/xemu-emu.AppImage --appimage-extract-and-run
+APP="/Applications/xemu-emu.AppImage"
+gow_log "Starting Xemu DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -full-screen
+fi
+
+if [[ "${1:-}" != -* ]]; then
+    exec "$APP" --appimage-extract-and-run -full-screen -dvd_path "$1"
+fi
+
+exec "$APP" --appimage-extract-and-run -full-screen "$@"

--- a/images/base-emu/build-fedora/launchers/xenia.sh
+++ b/images/base-emu/build-fedora/launchers/xenia.sh
@@ -2,9 +2,38 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-XENIA_WORKDIR="$HOME/.local/share/Xenia/root"
+XENIA_WORKDIR="${HOME}/.local/share/Xenia/root"
 mkdir -p "$XENIA_WORKDIR"
 
-gow_log "Starting Xenia Canary with DISPLAY=${DISPLAY} and working directory $XENIA_WORKDIR and args: $@"
+_xenia_bin() {
+    local candidate
+    for candidate in \
+        /Applications/xenia-canary/xenia_canary \
+        /Applications/xenia-canary/build/bin/Linux/Release/xenia_canary; do
+        if [[ -x "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+XENIA_BIN=$(_xenia_bin) || {
+    gow_log "ERROR: xenia_canary not found under /Applications/xenia-canary"
+    exit 1
+}
+
+gow_log "Starting Xenia Canary (${XENIA_BIN}) DISPLAY=${DISPLAY} args: $*"
 cd "$XENIA_WORKDIR"
-/Applications/xenia-canary/xenia_canary "$@"
+
+for arg in "$@"; do
+    if [[ "$arg" == "--fullscreen" ]]; then
+        exec "$XENIA_BIN" "$@"
+    fi
+done
+
+if [[ $# -eq 0 ]]; then
+    exec "$XENIA_BIN" --fullscreen
+fi
+
+exec "$XENIA_BIN" "$@" --fullscreen

--- a/images/base-emu/build/Dockerfile
+++ b/images/base-emu/build/Dockerfile
@@ -186,12 +186,14 @@ echo "**** Extracting Xenia Canary ****"
 mkdir -p xenia-canary
 tar -xf xenia_canary_linux.tar.xz -C xenia-canary
 rm xenia_canary_linux.tar.xz
+ln -sf build/bin/Linux/Release/xenia_canary xenia-canary/xenia_canary
 
 chmod -v -R 777 $EMULATORS_DIR
 chmod -v -R a+x $EMULATORS_DIR
 _INSTALL_EMULATORS
 
 COPY --chmod=777 launchers /Applications/launchers
+COPY --chmod=755 scripts/rom_platforms.py scripts/generate_rom_library_configs.py scripts/gow_refresh_rom_library.sh scripts/required_cores.py scripts/install_retroarch_cores.sh /opt/gow/rom-config/
 ENV PATH="/Applications/launchers:${PATH}"
 
 RUN \

--- a/images/base-emu/build/launchers/cemu.sh
+++ b/images/base-emu/build/launchers/cemu.sh
@@ -2,5 +2,15 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting CEMU with DISPLAY=${DISPLAY}"
-/Applications/cemu-emu.AppImage --appimage-extract-and-run
+APP="/Applications/cemu-emu.AppImage"
+gow_log "Starting Cemu DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -f
+fi
+
+if [[ "${1:-}" == -g && -n "${2:-}" ]]; then
+    exec "$APP" --appimage-extract-and-run -f -g "$2"
+fi
+
+exec "$APP" --appimage-extract-and-run -f "$@"

--- a/images/base-emu/build/launchers/citron.sh
+++ b/images/base-emu/build/launchers/citron.sh
@@ -2,5 +2,22 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting Citron with DISPLAY=${DISPLAY}"
-/Applications/citron.AppImage --appimage-extract-and-run "$@"
+APP="/Applications/citron.AppImage"
+gow_log "Starting Citron DISPLAY=${DISPLAY} args: $*"
+
+if [[ ! -f "$APP" ]]; then
+    gow_log "ERROR: Citron AppImage missing at ${APP} (not bundled in current ES-DE image)"
+    exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -f
+fi
+
+for arg in "$@"; do
+    if [[ "$arg" == "-f" || "$arg" == "--fullscreen" ]]; then
+        exec "$APP" --appimage-extract-and-run "$@"
+    fi
+done
+
+exec "$APP" --appimage-extract-and-run -f "$@"

--- a/images/base-emu/build/launchers/dolphin.sh
+++ b/images/base-emu/build/launchers/dolphin.sh
@@ -2,5 +2,19 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting dolphin-emu with DISPLAY=${DISPLAY}"
-/Applications/dolphin-emu.AppImage --appimage-extract-and-run
+APP="/Applications/dolphin-emu.AppImage"
+gow_log "Starting dolphin-emu DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run --fullscreen
+fi
+
+if [[ "${1:-}" == --exec && -n "${2:-}" ]]; then
+    exec "$APP" --appimage-extract-and-run --batch --fullscreen --exec="$2"
+fi
+
+if [[ "${1:-}" == --exec=* ]]; then
+    exec "$APP" --appimage-extract-and-run --batch --fullscreen "$1"
+fi
+
+exec "$APP" --appimage-extract-and-run --batch --fullscreen --exec="$1"

--- a/images/base-emu/build/launchers/pcsx2.sh
+++ b/images/base-emu/build/launchers/pcsx2.sh
@@ -2,5 +2,11 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting PCSX2-QT with DISPLAY=${DISPLAY}"
-/Applications/pcsx2-emu.AppImage --appimage-extract-and-run
+APP="/Applications/pcsx2-emu.AppImage"
+gow_log "Starting PCSX2 DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -fullscreen
+fi
+
+exec "$APP" --appimage-extract-and-run -fullscreen "$@"

--- a/images/base-emu/build/launchers/retroarch.sh
+++ b/images/base-emu/build/launchers/retroarch.sh
@@ -2,5 +2,9 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting RetroArch with DISPLAY=${DISPLAY}"
-retroarch
+gow_log "Starting RetroArch DISPLAY=${DISPLAY} args: $*"
+if [[ $# -eq 0 ]]; then
+    exec retroarch --fullscreen
+fi
+
+exec retroarch --fullscreen "$@"

--- a/images/base-emu/build/launchers/rom_launcher.sh
+++ b/images/base-emu/build/launchers/rom_launcher.sh
@@ -2,55 +2,60 @@
 EMULATOR=$1
 ROM=$2
 
-# Mount location where we will mount both zip files and iso files
+# Profile-seeded launchers (repair-esde.sh); fall back to image path.
+GOW_LAUNCHERS="${GOW_LAUNCHERS:-/home/retro/Applications/launchers}"
+if [[ ! -d "$GOW_LAUNCHERS" ]]; then
+    GOW_LAUNCHERS="/Applications/launchers"
+fi
+
 ISO_MOUNT_LOCATION=/media/iso_mount
 
 function launch_ps3 {
+    local ROM_FILE="$1"
 
-  local ROM_FILE="$1"
+    if [[ $ROM_FILE == *.iso ]]; then
+        echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
+        fuseiso "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
+        ROM_FILE=${ISO_MOUNT_LOCATION}
+    fi
 
-  # Mount the folder/file if it's an iso
-  if [[ $ROM_FILE == *.iso ]]; then
-    echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
-    fuseiso "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
-    ROM_FILE=${ISO_MOUNT_LOCATION}
-  fi
+    "${GOW_LAUNCHERS}/rpcs3.sh" "${ROM_FILE}"
 
-  # Launch the game
-  /Applications/rpcs3-emu.AppImage --appimage-extract-and-run  "${ROM_FILE}"
-
-  # Unmount (if we mounted the ISO)
-  if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
-    echo "UnMounting: ${ISO_MOUNT_LOCATION}"
-    fusermount -u ${ISO_MOUNT_LOCATION}
-  fi
+    if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
+        echo "UnMounting: ${ISO_MOUNT_LOCATION}"
+        fusermount -u ${ISO_MOUNT_LOCATION}
+    fi
 }
 
 function launch_scummvm {
+    local ROM_FILE="$1"
 
-  local ROM_FILE="$1"
+    if [[ $ROM_FILE == *.zip ]]; then
+        echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
+        fuse-zip -o ro "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
+        ROM_FILE=${ISO_MOUNT_LOCATION}
+    fi
 
-  # Mount the folder/file if it's an iso
-  if [[ $ROM_FILE == *.zip ]]; then
-    echo "Mounting: ${ROM_FILE} to ${ISO_MOUNT_LOCATION}"
-    fuse-zip -o ro "${ROM_FILE}" ${ISO_MOUNT_LOCATION}
-    ROM_FILE=${ISO_MOUNT_LOCATION}
-  fi
+    SCUMMVM_FILE=`ls ${ISO_MOUNT_LOCATION}/*.scummvm`
 
-  # Find the .scummvm filename
-  SCUMMVM_FILE=`ls ${ISO_MOUNT_LOCATION}/*.scummvm`
+    retroarch --fullscreen -L ~/.config/retroarch/cores/scummvm_libretro.so ${SCUMMVM_FILE}
 
-  # Launch the game
-  retroarch -L ~/.config/retroarch/cores/scummvm_libretro.so ${SCUMMVM_FILE}
-
-  # Unmount (if we mounted the ISO)
-  if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
-    echo "UnMounting: ${ISO_MOUNT_LOCATION}"
-    fusermount -u ${ISO_MOUNT_LOCATION}
-  fi
+    if [[ "${ROM_FILE}" == "${ISO_MOUNT_LOCATION}" ]]; then
+        echo "UnMounting: ${ISO_MOUNT_LOCATION}"
+        fusermount -u ${ISO_MOUNT_LOCATION}
+    fi
 }
 
-# dictionary of emulator to command to run
+function launch_nes {
+    local ROM_FILE="$1"
+    local CORE_DIR="${HOME}/.config/retroarch/cores"
+    local CORE="fceumm_libretro.so"
+    if [[ ! -f "${CORE_DIR}/${CORE}" && -f "${CORE_DIR}/nestopia_libretro.so" ]]; then
+        CORE="nestopia_libretro.so"
+    fi
+    retroarch --fullscreen -L "${CORE_DIR}/${CORE}" "${ROM_FILE}"
+}
+
 declare -A EMULATOR_COMMAND=( \
 ["3do"]="retroarch --fullscreen -L ~/.config/retroarch/cores/opera_libretro.so \"${ROM}\"" \
 ["arcade"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mame_libretro.so \"${ROM}\"" \
@@ -66,34 +71,35 @@ declare -A EMULATOR_COMMAND=( \
 ["gb"]="retroarch --fullscreen -L ~/.config/retroarch/cores/gambatte_libretro.so \"${ROM}\"" \
 ["gbc"]="retroarch --fullscreen -L ~/.config/retroarch/cores/gambatte_libretro.so \"${ROM}\"" \
 ["gba"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mgba_libretro.so \"${ROM}\"" \
-["gc"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
+["gc"]="${GOW_LAUNCHERS}/dolphin.sh --exec \"${ROM}\"" \
 ["genesis"]="retroarch --fullscreen -L ~/.config/retroarch/cores/picodrive_libretro.so \"${ROM}\"" \
+["mastersystem"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
 ["megacd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
 ["model2"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mame_libretro.so \"${ROM}\"" \
 ["n64"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mupen64plus_next_libretro.so \"${ROM}\"" \
 ["naomi"]="retroarch --fullscreen -L ~/.config/retroarch/cores/flycast_libretro.so \"${ROM}\"" \
 ["neogeo"]="retroarch --fullscreen -L ~/.config/retroarch/cores/fbneo_libretro.so \"${ROM}\"" \
-["nes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/fceumm_libretro.so \"${ROM}\"" \
+["nes"]="launch_nes \"${ROM}\"" \
 ["ngp"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_ngp_libretro.so \"${ROM}\"" \
 ["ngpc"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_ngp_libretro.so \"${ROM}\"" \
 ["psp"]="retroarch --fullscreen -L ~/.config/retroarch/cores/ppsspp_libretro.so \"${ROM}\"" \
 ["psx"]="retroarch --fullscreen -L ~/.config/retroarch/cores/pcsx_rearmed_libretro.so \"${ROM}\"" \
-["ps2"]="/Applications/pcsx2-emu.AppImage --appimage-extract-and-run \"${ROM}\"" \
-["ps3"]="launch_ps3  \"${ROM}\"" \
+["ps2"]="${GOW_LAUNCHERS}/pcsx2.sh \"${ROM}\"" \
+["ps3"]="launch_ps3 \"${ROM}\"" \
 ["saturn"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_saturn_libretro.so \"${ROM}\"" \
 ["sega32x"]="retroarch --fullscreen -L ~/.config/retroarch/cores/picodrive_libretro.so \"${ROM}\"" \
 ["segacd"]="retroarch --fullscreen -L ~/.config/retroarch/cores/genesis_plus_gx_libretro.so \"${ROM}\"" \
 ["scummvm"]="launch_scummvm \"${ROM}\"" \
 ["snes"]="retroarch --fullscreen -L ~/.config/retroarch/cores/snes9x_libretro.so \"${ROM}\"" \
 ["snes_widescreen"]="retroarch --fullscreen -L ~/.config/retroarch/cores/bsnes_hd_beta_libretro.so \"${ROM}\"" \
-["switch"]="/Applications/launchers/citron.sh -f -g \"${ROM}\"" \
+["switch"]="${GOW_LAUNCHERS}/citron.sh -f -g \"${ROM}\"" \
 ["virtualboy"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_vb_libretro.so \"${ROM}\"" \
-["wii"]="/Applications/dolphin-emu.AppImage --appimage-extract-and-run --batch --exec=\"${ROM}\"" \
-["wiiu"]="/Applications/cemu-emu.AppImage --appimage-extract-and-run -f -g \"${ROM}\"" \
+["wii"]="${GOW_LAUNCHERS}/dolphin.sh --exec \"${ROM}\"" \
+["wiiu"]="${GOW_LAUNCHERS}/cemu.sh -g \"${ROM}\"" \
 ["wonderswan"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_wswan_libretro.so \"${ROM}\"" \
 ["wonderswancolor"]="retroarch --fullscreen -L ~/.config/retroarch/cores/mednafen_wswan_libretro.so \"${ROM}\"" \
-["xbox"]="/Applications/xemu-emu.AppImage --appimage-extract-and-run -full-screen -dvd_path \"${ROM}\"" \
-["xbox360"]="/Applications/launchers/xenia.sh --fullscreen \"${ROM}\"" \
+["xbox"]="${GOW_LAUNCHERS}/xemu.sh \"${ROM}\"" \
+["xbox360"]="${GOW_LAUNCHERS}/xenia.sh \"${ROM}\"" \
 )
 
 echo "Running command: ${EMULATOR_COMMAND[${EMULATOR}]}"

--- a/images/base-emu/build/launchers/rpcs3.sh
+++ b/images/base-emu/build/launchers/rpcs3.sh
@@ -2,5 +2,11 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting RPCS3 with DISPLAY=${DISPLAY}"
-/Applications/rpcs3-emu.AppImage --appimage-extract-and-run
+APP="/Applications/rpcs3-emu.AppImage"
+gow_log "Starting RPCS3 DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run
+fi
+
+exec "$APP" --appimage-extract-and-run "$@"

--- a/images/base-emu/build/launchers/xemu.sh
+++ b/images/base-emu/build/launchers/xemu.sh
@@ -2,5 +2,15 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-gow_log "Starting XEMU with DISPLAY=${DISPLAY}"
-/Applications/xemu-emu.AppImage --appimage-extract-and-run
+APP="/Applications/xemu-emu.AppImage"
+gow_log "Starting Xemu DISPLAY=${DISPLAY} args: $*"
+
+if [[ $# -eq 0 ]]; then
+    exec "$APP" --appimage-extract-and-run -full-screen
+fi
+
+if [[ "${1:-}" != -* ]]; then
+    exec "$APP" --appimage-extract-and-run -full-screen -dvd_path "$1"
+fi
+
+exec "$APP" --appimage-extract-and-run -full-screen "$@"

--- a/images/base-emu/build/launchers/xenia.sh
+++ b/images/base-emu/build/launchers/xenia.sh
@@ -2,9 +2,38 @@
 set -e
 source /opt/gow/bash-lib/utils.sh
 
-XENIA_WORKDIR="$HOME/.local/share/Xenia/root"
+XENIA_WORKDIR="${HOME}/.local/share/Xenia/root"
 mkdir -p "$XENIA_WORKDIR"
 
-gow_log "Starting Xenia Canary with DISPLAY=${DISPLAY} and working directory $XENIA_WORKDIR and args: $@"
+_xenia_bin() {
+    local candidate
+    for candidate in \
+        /Applications/xenia-canary/xenia_canary \
+        /Applications/xenia-canary/build/bin/Linux/Release/xenia_canary; do
+        if [[ -x "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+XENIA_BIN=$(_xenia_bin) || {
+    gow_log "ERROR: xenia_canary not found under /Applications/xenia-canary"
+    exit 1
+}
+
+gow_log "Starting Xenia Canary (${XENIA_BIN}) DISPLAY=${DISPLAY} args: $*"
 cd "$XENIA_WORKDIR"
-/Applications/xenia-canary/xenia_canary "$@"
+
+for arg in "$@"; do
+    if [[ "$arg" == "--fullscreen" ]]; then
+        exec "$XENIA_BIN" "$@"
+    fi
+done
+
+if [[ $# -eq 0 ]]; then
+    exec "$XENIA_BIN" --fullscreen
+fi
+
+exec "$XENIA_BIN" "$@" --fullscreen


### PR DESCRIPTION
## Summary
- Update base-emu launcher scripts for ROM-aware Dolphin, Cemu, Xemu, Xenia, PCSX2, RPCS3, Citron, and RetroArch
- Fix Xenia binary resolution under \uild/bin/Linux/Release/xenia_canary\ with a Dockerfile symlink
- Launch emulators in fullscreen for Moonlight/Wolf streaming sessions
- Improve \om_launcher.sh\ platform map and PS3 ISO fuse handling

## Why
Wolf virtual sessions commonly launch games through ES-DE and \om_launcher.sh\. The previous Xenia path was wrong, batch Dolphin launches lacked fullscreen, and several standalone scripts did not handle ROM arguments consistently in streamed environments.

## Test plan
- [ ] Build \ase-emu\ image (ubuntu + fedora variants)
- [ ] Launch GC/Wii, PS2, Xbox, Xbox 360 from ES-DE
- [ ] Confirm fullscreen and controller input
- [ ] Alt+F4 returns to ES-DE with RunInBackground enabled

Made with [Cursor](https://cursor.com)