### PR TITLE
Add info about Docker BuildKit

### DIFF
--- a/website/content/dev/manual-build.md
+++ b/website/content/dev/manual-build.md
@@ -15,6 +15,12 @@ git clone https://github.com/games-on-whales/gow.git
 All the published images are in the `apps/` directory.
 You can edit any of the images or create a new one.
 
+**Ensure Docker BuildKit is installed and used, otherwise some `Dockerfile`s with here-docs will fail to execute some commands, with errors similar to:**
+```log
+/bin/sh: line 1: warning: here-document at line 1 delimited by end-of-file (wanted `_INSTALL_PACKAGES')
+```
+You can enable this by setting `DOCKER_BUILDKIT=1` when running `docker build ...`, or by using `docker buildx build ...`
+
 ## Example: edit an already existing image
 
 For example, say that you want to add another emulator to `ES-DE`:


### PR DESCRIPTION
Because somehow that wasn't installed or used on my machine, causing very odd issues with Docker files during build.

Specifically heredocs failed, such as
```dockerfile
RUN <<_INSTALL_PACKAGES
(a few commands to install necessary packages)
_INSTALLPACKAGES
```
It would skip over this entire section, merely reporting in the log

```log
/bin/sh: line 1: warning: here-document at line 1 delimited by end-of-file (wanted `_INSTALL_PACKAGES')
```

I know it skipped it, because it took way too little time (something ridiculous like 0.2s) to download and install packages.

Considering the github runner files already use buildx/buildkit, this info will hopefully ensure nobody accidentally builds images different to the official ones.