### PR TITLE
nvidia-driver: auto-detect host driver version and initialize the volume on start

### DIFF
--- a/bin/build-app.sh
+++ b/bin/build-app.sh
@@ -3,20 +3,20 @@ set -euo pipefail
 
 # First argument controls the app to build (ex: steam)
 APP_NAME=${1:-"steam"}
-# Second argument controls the variant of the image (ex: -fedora)
-IMAGE_VARIANT=${2:-"-fedora"}
+# Second argument controls the variant of the image (ex: -fedora, type '' if you want default variant)
+IMAGE_VARIANT=${2-"-fedora"}
 
 echo "======================================"
 echo "🔨 Building gow/base${IMAGE_VARIANT}..."
-docker build -t gow/base${IMAGE_VARIANT} images/base/build${IMAGE_VARIANT} --progress=plain
+docker build -t "gow/base${IMAGE_VARIANT}" "images/base/build${IMAGE_VARIANT}" --progress=plain
 echo "🌟 Built gow/base${IMAGE_VARIANT}"
 
 echo "======================================"
 echo "🔨 Building gow/base-app${IMAGE_VARIANT}..."
-docker build --build-arg BASE_IMAGE=gow/base${IMAGE_VARIANT} -t gow/base-app${IMAGE_VARIANT} images/base-app/build${IMAGE_VARIANT} --progress=plain
+docker build --build-arg "BASE_IMAGE=gow/base${IMAGE_VARIANT}" -t "gow/base-app${IMAGE_VARIANT}" "images/base-app/build${IMAGE_VARIANT}" --progress=plain
 echo "🌟 Built gow/base-app${IMAGE_VARIANT}"
 
 echo "======================================"
 echo "🔨 Building ${APP_NAME} image..."
-docker build --build-arg BASE_APP_IMAGE=gow/base-app${IMAGE_VARIANT} -t gow/${APP_NAME}${IMAGE_VARIANT} apps/${APP_NAME}/build${IMAGE_VARIANT} --progress=plain
+docker build --build-arg "BASE_APP_IMAGE=gow/base-app${IMAGE_VARIANT}" -t "gow/${APP_NAME}${IMAGE_VARIANT}" "apps/${APP_NAME}/build${IMAGE_VARIANT}" --progress=plain
 echo "🌟 Built gow/${APP_NAME}${IMAGE_VARIANT}"

--- a/images/nvidia-driver/Dockerfile
+++ b/images/nvidia-driver/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:22.04 AS nvidia-installer
 
 ARG NV_VERSION
-RUN apt-get update -y && \
+RUN --mount=type=secret,id=nvidia-version,target=/nvidia-version \
+    NV_VERSION="${NV_VERSION:-$(cat /nvidia-version)}" && \
+    apt-get update -y && \
     apt-get install -y --no-install-recommends curl ca-certificates kmod pkg-config libglvnd-dev vulkan-tools && \
     curl -LO https://download.nvidia.com/XFree86/Linux-x86_64/$NV_VERSION/NVIDIA-Linux-x86_64-$NV_VERSION.run && \
     chmod +x NVIDIA-Linux-x86_64-$NV_VERSION.run && mkdir -p /usr/nvidia && \
@@ -12,8 +14,10 @@ RUN apt-get update -y && \
 RUN echo -e "/usr/nvidia/lib\n/usr/nvidia/lib32" > /etc/ld.so.conf.d/nvidia.conf && ldconfig
 
 ################
-FROM scratch
+FROM nvidia-installer
 
 COPY --from=nvidia-installer /usr/nvidia/ /usr/nvidia
 COPY --from=nvidia-installer /etc/vulkan/icd.d/nvidia_icd.json /usr/nvidia/share/vulkan/icd.d/
-COPY --from=nvidia-installer /bin/sh /bin/sh
+ADD docker-entrypoint.bash /
+
+ENTRYPOINT ["/docker-entrypoint.bash"]

--- a/images/nvidia-driver/docker-entrypoint.bash
+++ b/images/nvidia-driver/docker-entrypoint.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+readonly NV_SOURCE_DIR="${NV_SOURCE_DIR:-/usr/nvidia/}"
+readonly NV_TARGET_DIR="${NV_TARGET_DIR:-/usr/nvidia.init/}"
+
+echo 'Checking environment requirements...' >&2
+for module in nvidia nvidia_uvm; do
+  if ! grep -q "$module " /proc/modules; then
+    echo "Module '$module' is not loaded! See the 'Nvidia (Manual)' section in the docs how to enable and load it."
+    exit 1
+  fi
+done
+if [[ $(</sys/module/nvidia_drm/parameters/modeset) != 'Y' ]]; then
+  echo "Module 'nvidia_drm' has no modeset enabled! See the 'Nvidia (Manual)' section in the docs how to enable it."
+  exit 1
+fi
+
+echo "Cleaning '${NV_TARGET_DIR}' for fresh drivers install..." >&2
+rm -rf "${NV_TARGET_DIR}/"*
+echo "Copying new version of drivers from '${NV_SOURCE_DIR}' to '${NV_TARGET_DIR}'..." >&2
+cp -a "${NV_SOURCE_DIR}/." "${NV_TARGET_DIR}"
+
+exec "$@"


### PR DESCRIPTION
## What

Makes the `nvidia-driver` image self-sufficient: it now detects the host driver version at build time and populates the driver volume by itself on container start, instead of requiring the user to pass `NV_VERSION` manually and run a separate one-shot container to seed the volume.

## Changes

**`images/nvidia-driver/Dockerfile`**

- `NV_VERSION` can now be supplied through a BuildKit secret mounted at `/nvidia-version`, falling back to the existing `ARG NV_VERSION` when the secret is absent:
  ```dockerfile
  RUN --mount=type=secret,id=nvidia-version,target=/nvidia-version \
      NV_VERSION="${NV_VERSION:-$(cat /nvidia-version)}" && \
      ...
  ```
  This lets Compose feed `/sys/module/nvidia/version` straight from the host, so the image always matches the running kernel driver — no manual version bookkeeping, no drift after a host driver upgrade.
- The final stage moves from `FROM scratch` to `FROM nvidia-installer`, so the image has a usable runtime for the entrypoint.
- Adds `docker-entrypoint.bash` as `ENTRYPOINT`.

**`images/nvidia-driver/docker-entrypoint.bash`** (new)

1. **Preflight checks** — fails fast with an actionable message instead of leaving a silently broken setup:
   - `nvidia` and `nvidia_uvm` modules are loaded (`/proc/modules`)
   - `nvidia_drm` has `modeset=Y`
2. **Volume initialization** — clears `${NV_TARGET_DIR}` (default `/usr/nvidia.init/`) and copies the driver tree from `${NV_SOURCE_DIR}` (default `/usr/nvidia/`), so a rebuilt image refreshes the volume rather than layering a new driver over an old one.
3. `exec "$@"`

Both directories are overridable via env vars.

**`bin/build-app.sh`** (drive-by, needed to build this image locally)

- `IMAGE_VARIANT` now expands with `${2-"-fedora"}` instead of `${2:-"-fedora"}`, so an explicitly empty second argument selects the variant-less (default) images — `images/base/build` instead of `images/base/build-fedora`. Previously `''` was silently rewritten back to `-fedora`, which made the default variant unreachable through this script. Omitting the argument still defaults to `-fedora`, so existing invocations are unaffected.

  ```console
  ./bin/build-app.sh steam ''   # gow/base, gow/base-app, gow/steam
  ./bin/build-app.sh steam      # gow/base-fedora, gow/base-app-fedora, gow/steam-fedora
  ```

## Usage

Intended to run as a Compose init service that Wolf depends on:

```yaml
services:
  init-nvidia-driver:
    image: gow/nvidia-driver:latest
    build:
      context: https://github.com/games-on-whales/gow.git#master:/images/nvidia-driver/
      secrets:
        - nvidia-version
    pull_policy: build
    volumes:
      - nvidia-driver-vol:/usr/nvidia.init/:rw

  wolf:
    depends_on:
      init-nvidia-driver:
        condition: service_completed_successfully
        restart: true
    # ...

secrets:
  nvidia-version:
    file: /sys/module/nvidia/version
```

## Related

Companion documentation PR in the Wolf repository, which adds the **Nvidia (Auto)** tab to the Quickstart guide describing this workflow: https://github.com/games-on-whales/wolf/pull/470

The two changes are complementary — this PR provides the mechanism, the Wolf PR documents it. The Compose example in the Wolf docs builds from `games-on-whales/gow.git#master`, so it only works once this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

